### PR TITLE
Add ci-failure-fix workflow (three-tier mitigation) + feedback scoring

### DIFF
--- a/.github/workflows/ci-failure-fix.lock.yml
+++ b/.github/workflows/ci-failure-fix.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ffde252fef4f21a9b868e0aeaf29b1731c00faaaddcf494ca0605e87470a5d13","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","COPILOT_PAT_0","COPILOT_PAT_1","COPILOT_PAT_2","COPILOT_PAT_3","COPILOT_PAT_4","COPILOT_PAT_5","COPILOT_PAT_6","COPILOT_PAT_7","COPILOT_PAT_8","COPILOT_PAT_9","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"715e05bff55b1d42e09145e91a4ca2ad6a2b6bba74a090bd216b98c0baa15653","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","COPILOT_PAT_0","COPILOT_PAT_1","COPILOT_PAT_2","COPILOT_PAT_3","COPILOT_PAT_4","COPILOT_PAT_5","COPILOT_PAT_6","COPILOT_PAT_7","COPILOT_PAT_8","COPILOT_PAT_9","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Periodic scan of runtime-extra-platforms and outer-loop CI pipelines (JIT/GC stress, PGO, libraries-jitstress, etc.). Files Known Build Errors so failures are immediately ignorable in PR CI. Detection only — mitigation (fix PRs and owner hand-off) is owned by the companion ci-failure-fix workflow; this scan never disables tests.
+# Periodic pass over open [ci-scan] Known Build Errors. Always attempts a real fix. When the fix is small and build-validated it opens a confident draft fix PR; when a fix is plausible but unvalidated or out of small-fix bounds it still opens a draft 'help wanted' PR carrying the best-effort change plus root-cause analysis and an explicit request for help from the likely regression author and area owners. Only when no code change can be produced at all (JIT/GC codegen, security/API design, pure infra) does it fall back to a single root-cause loop-in comment. Never disables or mutes tests.
 #
 # Resolved workflow manifest:
 #   Imports:
@@ -40,6 +40,7 @@
 #   - COPILOT_PAT_7
 #   - COPILOT_PAT_8
 #   - COPILOT_PAT_9
+#   - GH_AW_CI_TRIGGER_TOKEN
 #   - GH_AW_GITHUB_MCP_SERVER_TOKEN
 #   - GH_AW_GITHUB_TOKEN
 #   - GITHUB_TOKEN
@@ -60,7 +61,7 @@
 #   - ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959
 #   - node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
 
-name: "CI Outer-Loop Failure Scanner"
+name: "CI Outer-Loop Failure Fixer"
 "on":
   # permissions: {} # Permissions applied to pre-activation job
   # roles: # Roles processed as role check in pre-activation job
@@ -68,7 +69,7 @@ name: "CI Outer-Loop Failure Scanner"
   # - maintainer # Roles processed as role check in pre-activation job
   # - write # Roles processed as role check in pre-activation job
   schedule:
-  - cron: "34 */12 * * *"
+  - cron: "54 */12 * * *"
     # Friendly format: every 12h (scattered)
   workflow_dispatch:
     inputs:
@@ -82,9 +83,9 @@ permissions: {}
 
 concurrency:
   cancel-in-progress: true
-  group: ci-failure-scan
+  group: ci-failure-fix
 
-run-name: "CI Outer-Loop Failure Scanner"
+run-name: "CI Outer-Loop Failure Fixer"
 
 jobs:
   activation:
@@ -114,8 +115,8 @@ jobs:
           job-name: ${{ github.job }}
           trace-id: ${{ needs.pre_activation.outputs.setup-trace-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "CI Outer-Loop Failure Scanner"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/ci-failure-scan.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "CI Outer-Loop Failure Fixer"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/ci-failure-fix.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
       - name: Generate agentic run info
         id: generate_aw_info
@@ -126,7 +127,7 @@ jobs:
           GH_AW_INFO_VERSION: "1.0.40"
           GH_AW_INFO_AGENT_VERSION: "1.0.40"
           GH_AW_INFO_CLI_VERSION: "v0.71.5"
-          GH_AW_INFO_WORKFLOW_NAME: "CI Outer-Loop Failure Scanner"
+          GH_AW_INFO_WORKFLOW_NAME: "CI Outer-Loop Failure Fixer"
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
@@ -173,7 +174,7 @@ jobs:
         id: check-lock-file
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          GH_AW_WORKFLOW_FILE: "ci-failure-scan.lock.yml"
+          GH_AW_WORKFLOW_FILE: "ci-failure-fix.lock.yml"
           GH_AW_CONTEXT_WORKFLOW_REF: "${{ github.workflow_ref }}"
         with:
           script: |
@@ -207,20 +208,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_02e6cb6074561119_EOF'
+          cat << 'GH_AW_PROMPT_f9c00c6ec5ddd46f_EOF'
           <system>
-          GH_AW_PROMPT_02e6cb6074561119_EOF
+          GH_AW_PROMPT_f9c00c6ec5ddd46f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_02e6cb6074561119_EOF'
+          cat << 'GH_AW_PROMPT_f9c00c6ec5ddd46f_EOF'
           <safe-output-tools>
-          Tools: create_issue(max:5), missing_tool, missing_data, noop
+          Tools: add_comment(max:10), create_pull_request(max:5), missing_tool, missing_data, noop
+          GH_AW_PROMPT_f9c00c6ec5ddd46f_EOF
+          cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
+          cat << 'GH_AW_PROMPT_f9c00c6ec5ddd46f_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_02e6cb6074561119_EOF
+          GH_AW_PROMPT_f9c00c6ec5ddd46f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_02e6cb6074561119_EOF'
+          cat << 'GH_AW_PROMPT_f9c00c6ec5ddd46f_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -248,16 +252,16 @@ jobs:
           - **workflow-run-id**: __GH_AW_GITHUB_RUN_ID__
           {{/if}}
           - **checkouts**: The following repositories have been checked out and are available in the workspace:
-            - `$GITHUB_WORKSPACE` → `__GH_AW_GITHUB_REPOSITORY__` (cwd) [shallow clone, fetch-depth=50]
+            - `$GITHUB_WORKSPACE` → `__GH_AW_GITHUB_REPOSITORY__` (cwd) [shallow clone, fetch-depth=200]
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_02e6cb6074561119_EOF
+          GH_AW_PROMPT_f9c00c6ec5ddd46f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_02e6cb6074561119_EOF'
+          cat << 'GH_AW_PROMPT_f9c00c6ec5ddd46f_EOF'
           </system>
-          {{#runtime-import .github/workflows/ci-failure-scan.md}}
-          GH_AW_PROMPT_02e6cb6074561119_EOF
+          {{#runtime-import .github/workflows/ci-failure-fix.md}}
+          GH_AW_PROMPT_f9c00c6ec5ddd46f_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -348,7 +352,7 @@ jobs:
       GH_AW_ASSETS_BRANCH: ""
       GH_AW_ASSETS_MAX_SIZE_KB: 0
       GH_AW_MCP_LOG_DIR: /tmp/gh-aw/mcp-logs/safeoutputs
-      GH_AW_WORKFLOW_ID_SANITIZED: cifailurescan
+      GH_AW_WORKFLOW_ID_SANITIZED: cifailurefix
     outputs:
       agentic_engine_timeout: ${{ steps.detect-copilot-errors.outputs.agentic_engine_timeout || 'false' }}
       checkout_pr_success: ${{ steps.checkout-pr.outputs.checkout_pr_success || 'true' }}
@@ -370,8 +374,8 @@ jobs:
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "CI Outer-Loop Failure Scanner"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/ci-failure-scan.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "CI Outer-Loop Failure Fixer"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/ci-failure-fix.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
       - name: Set runtime paths
         id: set-runtime-paths
@@ -385,7 +389,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-          fetch-depth: 50
+          fetch-depth: 200
       - name: Create gh-aw temp directory
         run: bash "${RUNNER_TEMP}/gh-aw/actions/create_gh_aw_tmp_dir.sh"
       - name: Configure gh CLI for GitHub Enterprise
@@ -450,22 +454,23 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_d313a6a28782e059_EOF'
-          {"create_issue":{"allowed_labels":["Known Build Error","blocking-clean-ci"],"labels":["agentic-workflows"],"max":5},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_d313a6a28782e059_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_faecdd6500ee5c00_EOF'
+          {"add_comment":{"max":10,"target":"*"},"create_pull_request":{"allowed_files":["src/libraries/**","src/coreclr/**","src/mono/**","src/tests/**","src/native/**","eng/testing/**"],"draft":true,"labels":["agentic-workflows"],"max":5,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"blocked","title_prefix":"[ci-fix] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_faecdd6500ee5c00_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_issue": " CONSTRAINTS: Maximum 5 issue(s) can be created. Labels [\"agentic-workflows\"] will be automatically added. Only these labels are allowed: [\"Known Build Error\" \"blocking-clean-ci\"]."
+                "add_comment": " CONSTRAINTS: Maximum 10 comment(s) can be added. Target: *. Supports reply_to_id for discussion threading.",
+                "create_pull_request": " CONSTRAINTS: Maximum 5 pull request(s) can be created. Title will be prefixed with \"[ci-fix] \". Labels [\"agentic-workflows\"] will be automatically added. Only these labels are allowed: [\"agentic-workflows\"]. PRs will be created as drafts."
               },
               "repo_params": {},
               "dynamic_tools": []
             }
           GH_AW_VALIDATION_JSON: |
             {
-              "create_issue": {
+              "add_comment": {
                 "defaultMax": 1,
                 "fields": {
                   "body": {
@@ -474,21 +479,51 @@ jobs:
                     "sanitize": true,
                     "maxLength": 65000
                   },
+                  "item_number": {
+                    "issueOrPRNumber": true
+                  },
+                  "reply_to_id": {
+                    "type": "string",
+                    "maxLength": 256
+                  },
+                  "repo": {
+                    "type": "string",
+                    "maxLength": 256
+                  }
+                }
+              },
+              "create_pull_request": {
+                "defaultMax": 1,
+                "fields": {
+                  "base": {
+                    "type": "string",
+                    "sanitize": true,
+                    "maxLength": 128
+                  },
+                  "body": {
+                    "required": true,
+                    "type": "string",
+                    "sanitize": true,
+                    "maxLength": 65000
+                  },
+                  "branch": {
+                    "required": true,
+                    "type": "string",
+                    "sanitize": true,
+                    "maxLength": 256
+                  },
+                  "draft": {
+                    "type": "boolean"
+                  },
                   "labels": {
                     "type": "array",
                     "itemType": "string",
                     "itemSanitize": true,
                     "itemMaxLength": 128
                   },
-                  "parent": {
-                    "issueOrPRNumber": true
-                  },
                   "repo": {
                     "type": "string",
                     "maxLength": 256
-                  },
-                  "temporary_id": {
-                    "type": "string"
                   },
                   "title": {
                     "required": true,
@@ -650,7 +685,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_46d2b0620744f6a0_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_bf5d71e246b7b42a_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -694,7 +729,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_46d2b0620744f6a0_EOF
+          GH_AW_MCP_CONFIG_bf5d71e246b7b42a_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -734,6 +769,14 @@ jobs:
         # --allow-tool shell(echo)
         # --allow-tool shell(env)
         # --allow-tool shell(find)
+        # --allow-tool shell(git add:*)
+        # --allow-tool shell(git branch:*)
+        # --allow-tool shell(git checkout:*)
+        # --allow-tool shell(git commit:*)
+        # --allow-tool shell(git merge:*)
+        # --allow-tool shell(git rm:*)
+        # --allow-tool shell(git status)
+        # --allow-tool shell(git switch:*)
         # --allow-tool shell(git:*)
         # --allow-tool shell(grep)
         # --allow-tool shell(head)
@@ -764,7 +807,7 @@ jobs:
           printf '%s\n' '{"$schema":"https://github.com/github/gh-aw-firewall/releases/download/v0.25.40/awf-config.schema.json","network":{"allowDomains":["*.blob.core.windows.net","*.githubusercontent.com","api.business.githubcopilot.com","api.enterprise.githubcopilot.com","api.github.com","api.githubcopilot.com","api.individual.githubcopilot.com","api.snapcraft.io","archive.ubuntu.com","azure.archive.ubuntu.com","codeload.github.com","crl.geotrust.com","crl.globalsign.com","crl.identrust.com","crl.sectigo.com","crl.thawte.com","crl.usertrust.com","crl.verisign.com","crl3.digicert.com","crl4.digicert.com","crls.ssl.com","dev.azure.com","docs.github.com","github-cloud.githubusercontent.com","github-cloud.s3.amazonaws.com","github.blog","github.com","github.githubassets.com","helix.dot.net","host.docker.internal","json-schema.org","json.schemastore.org","keyserver.ubuntu.com","lfs.github.com","objects.githubusercontent.com","ocsp.digicert.com","ocsp.geotrust.com","ocsp.globalsign.com","ocsp.identrust.com","ocsp.sectigo.com","ocsp.ssl.com","ocsp.thawte.com","ocsp.usertrust.com","ocsp.verisign.com","packagecloud.io","packages.cloud.google.com","packages.microsoft.com","ppa.launchpad.net","raw.githubusercontent.com","registry.npmjs.org","s.symcb.com","s.symcd.com","security.ubuntu.com","telemetry.enterprise.githubcopilot.com","ts-crl.ws.symantec.com","ts-ocsp.ws.symantec.com","www.googleapis.com"]},"apiProxy":{"enabled":true,"models":{"auto":["large"],"deep-research":["copilot/deep-research*","google/deep-research*"],"gemini-flash":["copilot/gemini-*flash*","google/gemini-*flash*"],"gemini-pro":["copilot/gemini-*pro*","google/gemini-*pro*"],"gpt-4.1":["copilot/gpt-4.1*","openai/gpt-4.1*"],"gpt-5":["copilot/gpt-5*","openai/gpt-5*"],"gpt-5-codex":["copilot/gpt-5*codex*","openai/gpt-5*codex*"],"gpt-5-mini":["copilot/gpt-5*mini*","openai/gpt-5*mini*"],"gpt-5-nano":["copilot/gpt-5*nano*","openai/gpt-5*nano*"],"gpt-5-pro":["copilot/gpt-5*pro*","openai/gpt-5*pro*"],"haiku":["copilot/*haiku*","anthropic/*haiku*"],"large":["sonnet","gpt-5-pro","gpt-5","gemini-pro"],"mini":["haiku","gpt-5-mini","gpt-5-nano","gemini-flash"],"opus":["copilot/*opus*","anthropic/*opus*"],"reasoning":["copilot/o1*","copilot/o3*","copilot/o4*","openai/o1*","openai/o3*","openai/o4*"],"small":["mini"],"sonnet":["copilot/*sonnet*","anthropic/*sonnet*"]}},"container":{"imageTag":"0.25.40,squid=sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51,agent=sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504,api-proxy=sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280,cli-proxy=sha256:3e7152911d4b4b7b97beef9d3d7d924ff7902227e86001ef3838fb728d5d514c"}}' > "${RUNNER_TEMP}/gh-aw/awf-config.json" && cp "${RUNNER_TEMP}/gh-aw/awf-config.json" /tmp/gh-aw/awf-config.json
           # shellcheck disable=SC1003
           sudo -E awf --config "${RUNNER_TEMP}/gh-aw/awf-config.json" --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --env-all --exclude-env COPILOT_GITHUB_TOKEN --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --allow-host-ports 80,443,8080 --skip-pull \
-            -- /bin/bash -c 'export PATH="${RUNNER_TEMP}/gh-aw/mcp-cli/bin:$PATH" && export PATH="$(find /opt/hostedtoolcache /home/runner/work/_tool -maxdepth 4 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || echo node)"; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/copilot_harness.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-tool github --allow-tool safeoutputs --allow-tool '\''shell(awk)'\'' --allow-tool '\''shell(basename)'\'' --allow-tool '\''shell(bash)'\'' --allow-tool '\''shell(cat)'\'' --allow-tool '\''shell(chmod)'\'' --allow-tool '\''shell(curl:*)'\'' --allow-tool '\''shell(cut)'\'' --allow-tool '\''shell(date)'\'' --allow-tool '\''shell(dirname)'\'' --allow-tool '\''shell(dotnet:*)'\'' --allow-tool '\''shell(echo)'\'' --allow-tool '\''shell(env)'\'' --allow-tool '\''shell(find)'\'' --allow-tool '\''shell(git:*)'\'' --allow-tool '\''shell(grep)'\'' --allow-tool '\''shell(head)'\'' --allow-tool '\''shell(jq)'\'' --allow-tool '\''shell(ls)'\'' --allow-tool '\''shell(mkdir)'\'' --allow-tool '\''shell(pwd)'\'' --allow-tool '\''shell(safeoutputs:*)'\'' --allow-tool '\''shell(sed)'\'' --allow-tool '\''shell(sh)'\'' --allow-tool '\''shell(sort)'\'' --allow-tool '\''shell(tail)'\'' --allow-tool '\''shell(tee)'\'' --allow-tool '\''shell(test)'\'' --allow-tool '\''shell(tr)'\'' --allow-tool '\''shell(uniq)'\'' --allow-tool '\''shell(wc)'\'' --allow-tool '\''shell(xargs)'\'' --allow-tool '\''shell(yq)'\'' --allow-tool write --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
+            -- /bin/bash -c 'export PATH="${RUNNER_TEMP}/gh-aw/mcp-cli/bin:$PATH" && export PATH="$(find /opt/hostedtoolcache /home/runner/work/_tool -maxdepth 4 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || echo node)"; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/copilot_harness.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-tool github --allow-tool safeoutputs --allow-tool '\''shell(awk)'\'' --allow-tool '\''shell(basename)'\'' --allow-tool '\''shell(bash)'\'' --allow-tool '\''shell(cat)'\'' --allow-tool '\''shell(chmod)'\'' --allow-tool '\''shell(curl:*)'\'' --allow-tool '\''shell(cut)'\'' --allow-tool '\''shell(date)'\'' --allow-tool '\''shell(dirname)'\'' --allow-tool '\''shell(dotnet:*)'\'' --allow-tool '\''shell(echo)'\'' --allow-tool '\''shell(env)'\'' --allow-tool '\''shell(find)'\'' --allow-tool '\''shell(git add:*)'\'' --allow-tool '\''shell(git branch:*)'\'' --allow-tool '\''shell(git checkout:*)'\'' --allow-tool '\''shell(git commit:*)'\'' --allow-tool '\''shell(git merge:*)'\'' --allow-tool '\''shell(git rm:*)'\'' --allow-tool '\''shell(git status)'\'' --allow-tool '\''shell(git switch:*)'\'' --allow-tool '\''shell(git:*)'\'' --allow-tool '\''shell(grep)'\'' --allow-tool '\''shell(head)'\'' --allow-tool '\''shell(jq)'\'' --allow-tool '\''shell(ls)'\'' --allow-tool '\''shell(mkdir)'\'' --allow-tool '\''shell(pwd)'\'' --allow-tool '\''shell(safeoutputs:*)'\'' --allow-tool '\''shell(sed)'\'' --allow-tool '\''shell(sh)'\'' --allow-tool '\''shell(sort)'\'' --allow-tool '\''shell(tail)'\'' --allow-tool '\''shell(tee)'\'' --allow-tool '\''shell(test)'\'' --allow-tool '\''shell(tr)'\'' --allow-tool '\''shell(uniq)'\'' --allow-tool '\''shell(wc)'\'' --allow-tool '\''shell(xargs)'\'' --allow-tool '\''shell(yq)'\'' --allow-tool write --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_API_KEY: dummy-byok-key-for-offline-mode
@@ -972,10 +1015,12 @@ jobs:
       needs.activation.outputs.stale_lock_file_failed == 'true')
     runs-on: ubuntu-slim
     permissions:
-      contents: read
+      contents: write
+      discussions: write
       issues: write
+      pull-requests: write
     concurrency:
-      group: "gh-aw-conclusion-ci-failure-scan"
+      group: "gh-aw-conclusion-ci-failure-fix"
       cancel-in-progress: false
     outputs:
       incomplete_count: ${{ steps.report_incomplete.outputs.incomplete_count }}
@@ -991,8 +1036,8 @@ jobs:
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "CI Outer-Loop Failure Scanner"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/ci-failure-scan.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "CI Outer-Loop Failure Fixer"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/ci-failure-fix.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
       - name: Download agent output artifact
         id: download-agent-output
@@ -1014,7 +1059,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: "1"
-          GH_AW_WORKFLOW_NAME: "CI Outer-Loop Failure Scanner"
+          GH_AW_WORKFLOW_NAME: "CI Outer-Loop Failure Fixer"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_REPORT_AS_ISSUE: "true"
@@ -1030,7 +1075,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "CI Outer-Loop Failure Scanner"
+          GH_AW_WORKFLOW_NAME: "CI Outer-Loop Failure Fixer"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_DETECTION_CONCLUSION: ${{ needs.detection.outputs.detection_conclusion }}
           GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
@@ -1047,7 +1092,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_MISSING_TOOL_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "CI Outer-Loop Failure Scanner"
+          GH_AW_WORKFLOW_NAME: "CI Outer-Loop Failure Fixer"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1061,7 +1106,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_REPORT_INCOMPLETE_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "CI Outer-Loop Failure Scanner"
+          GH_AW_WORKFLOW_NAME: "CI Outer-Loop Failure Fixer"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1075,10 +1120,10 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "CI Outer-Loop Failure Scanner"
+          GH_AW_WORKFLOW_NAME: "CI Outer-Loop Failure Fixer"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
-          GH_AW_WORKFLOW_ID: "ci-failure-scan"
+          GH_AW_WORKFLOW_ID: "ci-failure-fix"
           GH_AW_ACTION_FAILURE_ISSUE_EXPIRES_HOURS: "168"
           GH_AW_ENGINE_ID: "copilot"
           GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
@@ -1088,6 +1133,8 @@ jobs:
           GH_AW_AGENTIC_ENGINE_TIMEOUT: ${{ needs.agent.outputs.agentic_engine_timeout }}
           GH_AW_MODEL_NOT_SUPPORTED_ERROR: ${{ needs.agent.outputs.model_not_supported_error }}
           GH_AW_ENGINE_API_HOSTS: "api.enterprise.githubcopilot.com,api.githubcopilot.com,api.business.githubcopilot.com,api.individual.githubcopilot.com"
+          GH_AW_CODE_PUSH_FAILURE_ERRORS: ${{ needs.safe_outputs.outputs.code_push_failure_errors }}
+          GH_AW_CODE_PUSH_FAILURE_COUNT: ${{ needs.safe_outputs.outputs.code_push_failure_count }}
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
           GH_AW_GROUP_REPORTS: "false"
@@ -1125,8 +1172,8 @@ jobs:
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "CI Outer-Loop Failure Scanner"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/ci-failure-scan.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "CI Outer-Loop Failure Fixer"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/ci-failure-fix.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
       - name: Download agent output artifact
         id: download-agent-output
@@ -1192,8 +1239,8 @@ jobs:
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          WORKFLOW_NAME: "CI Outer-Loop Failure Scanner"
-          WORKFLOW_DESCRIPTION: "Periodic scan of runtime-extra-platforms and outer-loop CI pipelines (JIT/GC stress, PGO, libraries-jitstress, etc.). Files Known Build Errors so failures are immediately ignorable in PR CI. Detection only — mitigation (fix PRs and owner hand-off) is owned by the companion ci-failure-fix workflow; this scan never disables tests."
+          WORKFLOW_NAME: "CI Outer-Loop Failure Fixer"
+          WORKFLOW_DESCRIPTION: "Periodic pass over open [ci-scan] Known Build Errors. Always attempts a real fix. When the fix is small and build-validated it opens a confident draft fix PR; when a fix is plausible but unvalidated or out of small-fix bounds it still opens a draft 'help wanted' PR carrying the best-effort change plus root-cause analysis and an explicit request for help from the likely regression author and area owners. Only when no code change can be produced at all (JIT/GC codegen, security/API design, pure infra) does it fall back to a single root-cause loop-in comment. Never disables or mutes tests."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1381,8 +1428,8 @@ jobs:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "CI Outer-Loop Failure Scanner"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/ci-failure-scan.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "CI Outer-Loop Failure Fixer"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/ci-failure-fix.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
       - name: Check team membership for workflow
         id: check_membership
@@ -1405,26 +1452,30 @@ jobs:
     if: (!cancelled()) && needs.agent.result != 'skipped' && needs.detection.result == 'success'
     runs-on: ubuntu-slim
     permissions:
-      contents: read
+      contents: write
+      discussions: write
       issues: write
+      pull-requests: write
     timeout-minutes: 15
     env:
-      GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/ci-failure-scan"
+      GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/ci-failure-fix"
       GH_AW_DETECTION_CONCLUSION: ${{ needs.detection.outputs.detection_conclusion }}
       GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: "claude-opus-4.6"
       GH_AW_ENGINE_VERSION: "1.0.40"
-      GH_AW_WORKFLOW_ID: "ci-failure-scan"
-      GH_AW_WORKFLOW_NAME: "CI Outer-Loop Failure Scanner"
+      GH_AW_WORKFLOW_ID: "ci-failure-fix"
+      GH_AW_WORKFLOW_NAME: "CI Outer-Loop Failure Fixer"
     outputs:
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}
+      comment_id: ${{ steps.process_safe_outputs.outputs.comment_id }}
+      comment_url: ${{ steps.process_safe_outputs.outputs.comment_url }}
       create_discussion_error_count: ${{ steps.process_safe_outputs.outputs.create_discussion_error_count }}
       create_discussion_errors: ${{ steps.process_safe_outputs.outputs.create_discussion_errors }}
-      created_issue_number: ${{ steps.process_safe_outputs.outputs.created_issue_number }}
-      created_issue_url: ${{ steps.process_safe_outputs.outputs.created_issue_url }}
+      created_pr_number: ${{ steps.process_safe_outputs.outputs.created_pr_number }}
+      created_pr_url: ${{ steps.process_safe_outputs.outputs.created_pr_url }}
       process_safe_outputs_processed_count: ${{ steps.process_safe_outputs.outputs.processed_count }}
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
@@ -1436,8 +1487,8 @@ jobs:
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "CI Outer-Loop Failure Scanner"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/ci-failure-scan.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "CI Outer-Loop Failure Fixer"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/ci-failure-fix.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
       - name: Download agent output artifact
         id: download-agent-output
@@ -1453,6 +1504,34 @@ jobs:
           mkdir -p /tmp/gh-aw/
           find "/tmp/gh-aw/" -type f -print
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/agent_output.json" >> "$GITHUB_OUTPUT"
+      - name: Download patch artifact
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: agent
+          path: /tmp/gh-aw/
+      - name: Checkout repository
+        if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'create_pull_request')
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.base_ref || github.event.pull_request.base.ref || github.ref_name || github.event.repository.default_branch }}
+          token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+          fetch-depth: 1
+      - name: Configure Git credentials
+        if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'create_pull_request')
+        env:
+          REPO_NAME: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
+          GIT_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global am.keepcr true
+          # Re-authenticate git with GitHub token
+          SERVER_URL_STRIPPED="${SERVER_URL#https://}"
+          git remote set-url origin "https://x-access-token:${GIT_TOKEN}@${SERVER_URL_STRIPPED}/${REPO_NAME}.git"
+          echo "Git configured with standard GitHub Actions identity"
       - name: Configure GH_HOST for enterprise compatibility
         id: ghes-host-config
         shell: bash
@@ -1470,7 +1549,8 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.blob.core.windows.net,*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dev.azure.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,helix.dot.net,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"allowed_labels\":[\"Known Build Error\",\"blocking-clean-ci\"],\"labels\":[\"agentic-workflows\"],\"max\":5},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":10,\"target\":\"*\"},\"create_pull_request\":{\"allowed_files\":[\"src/libraries/**\",\"src/coreclr/**\",\"src/mono/**\",\"src/tests/**\",\"src/native/**\",\"eng/testing/**\"],\"draft\":true,\"labels\":[\"agentic-workflows\"],\"max\":5,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"blocked\",\"title_prefix\":\"[ci-fix] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/ci-failure-fix.md
+++ b/.github/workflows/ci-failure-fix.md
@@ -1,0 +1,383 @@
+---
+name: "CI Outer-Loop Failure Fixer"
+description: "Periodic pass over open [ci-scan] Known Build Errors. Always attempts a real fix. When the fix is small and build-validated it opens a confident draft fix PR; when a fix is plausible but unvalidated or out of small-fix bounds it still opens a draft 'help wanted' PR carrying the best-effort change plus root-cause analysis and an explicit request for help from the likely regression author and area owners. Only when no code change can be produced at all (JIT/GC codegen, security/API design, pure infra) does it fall back to a single root-cause loop-in comment. Never disables or mutes tests."
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+on:
+  schedule: every 12h
+  workflow_dispatch:
+  roles: [admin, maintainer, write]
+  permissions: {}
+
+if: |
+  github.repository == 'dotnet/runtime'
+
+# ###############################################################
+# Override COPILOT_GITHUB_TOKEN with a random PAT from the pool.
+# This stop-gap will be removed when org billing is available.
+# See: .github/workflows/shared/pat_pool.README.md for more info.
+# ###############################################################
+imports:
+  - shared/pat_pool.md
+
+engine:
+  id: copilot
+  model: claude-opus-4.6
+  env:
+    COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7, needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8, needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9, secrets.COPILOT_GITHUB_TOKEN) }}
+
+concurrency:
+  group: "ci-failure-fix"
+  cancel-in-progress: true
+
+tools:
+  github:
+    toolsets: [pull_requests, repos, issues, search]
+    min-integrity: approved
+  edit:
+  bash: ["dotnet", "git", "find", "ls", "cat", "grep", "head", "tail", "wc", "curl", "jq", "tee", "sed", "awk", "tr", "cut", "sort", "uniq", "xargs", "echo", "date", "mkdir", "test", "env", "basename", "dirname", "bash", "sh", "chmod"]
+
+checkout:
+  fetch-depth: 200
+
+safe-outputs:
+  create-pull-request:
+    title-prefix: "[ci-fix] "
+    draft: true
+    max: 5
+    protected-files: blocked
+    allowed-files:
+      - "src/libraries/**"
+      - "src/coreclr/**"
+      - "src/mono/**"
+      - "src/tests/**"
+      - "src/native/**"
+      - "eng/testing/**"
+    labels: [agentic-workflows]
+    allowed-labels: [agentic-workflows]
+  add-comment:
+    target: "*"
+    max: 10
+
+timeout-minutes: 90
+
+network:
+  allowed:
+    - defaults
+    - github
+    - dev.azure.com
+    - helix.dot.net
+    - "*.blob.core.windows.net"
+---
+
+# CI Outer-Loop Failure Fixer
+
+You are a CI remediation agent. Each scheduled run, you walk the open `[ci-scan]` Known Build Error (KBE) issues that [`ci-failure-scan`](ci-failure-scan.md) filed, and for each one you **always try to actually fix the failure**. The outcome is exactly one of:
+
+- **Fix it (confident)** — a small, build-validated product/test change removes the failure → a draft `[ci-fix]` pull request linked back to the KBE.
+- **Attempt + ask for help (not confident)** — you have a plausible candidate change but could not fully validate it, or it exceeds the small-fix bounds → you **still open a draft `[ci-fix]` PR** that carries that best-effort change, a full root-cause analysis, and an explicit "help wanted" request that loops in the likely author + area owners. Prefer this over a bare comment whenever you can produce *any* honest candidate diff.
+- **Loop-in comment (last resort)** — only when no code change can be produced at all (JIT/GC codegen you must not touch, security/API design decisions, or non-code/infra failures) → a single root-cause hand-off comment on the KBE that loops in the same people.
+
+You are the *mitigation* stage. `ci-failure-scan` only detects failures and files KBEs; it never disables tests. **You never mute, skip, or disable a test, and you never add `[ActiveIssue]` / `Skip` / `<*Incompatible>` annotations.** A failure is removed either by a real fix PR or by a human the PR/comment loops in. A "help wanted" PR is a genuine best-effort code change plus an ask for review — never a test-disable dressed up as a fix. The agent runs read-only; all writes go through `safe-outputs`.
+
+To suggest changes, edit this file or comment on the PRs/comments it produces — the [`ci-failure-scan-feedback`](ci-failure-scan-feedback.md) workflow reads recent runs and that feedback daily, and opens (or updates) a single draft PR with proposed edits to either prompt.
+
+## Hard rules — non-negotiable
+
+1. **All writes via `safe-outputs`.** No `issues: write`, no `contents: write`. Don't try to use `gh` to write. The only outputs are `create_pull_request` and `add_comment`.
+2. **Caps per run: 5 `create_pull_request`, 10 `add_comment`.** On cap, record `-> skipped: cap reached` and move on.
+3. **Never mute.** No `[ActiveIssue]`, `[SkipOnPlatform]`, `[ConditionalFact]` added to disable, `<GCStressIncompatible>`, `<NativeAotIncompatible>`, `<*TestUnsupported>`, `Skip = "..."`, or any csproj exclusion that stops a test from running. If the only available mitigation is to disable a test, do NOT do it — open a help-wanted PR with a non-disabling best-effort change, or (if no code change is possible) a loop-in comment. Disabling is a human decision that lives outside this workflow.
+4. **One KBE = one outcome per run.** Exactly one of: a fix PR (confident or help-wanted), a loop-in comment, or a recorded skip. Never both a PR and a comment for the same KBE in the same run; always prefer the PR.
+5. **At most one open `[ci-fix]` PR and one `ci-fix` loop-in comment per KBE, ever.** Before opening a PR, run the Step 3 PR dedup. Before commenting, search for a prior `ci-fix` comment on that KBE (the marker `<!-- ci-fix:handoff -->`). If a comment already exists, skip with `-> skipped: loop-in comment already posted`. Build Analysis tracks occurrence counts in the KBE body; do not add occurrence chatter.
+6. **Every PR title starts with `[ci-fix] `.** Every PR body and every loop-in comment carries the artifact marker block (see Output markers).
+7. **Cross-run dedup is GitHub-search based, not `/tmp`.** `/tmp/gh-aw/agent/` is per-run only. Before emitting anything for a KBE, run the existing-artifact searches in Step 3 against live GitHub.
+8. **Fixes are small and validated; help-wanted PRs are honest.** A confident fix PR satisfies the small-fix bounds in Step 5 and is build-validated. A help-wanted PR may exceed those bounds or be unvalidated, but it MUST stay draft, carry a real best-effort diff (never a test-disable), and state plainly in the body what is unverified and what help is needed.
+9. **All intermediate state under `/tmp/gh-aw/agent/`.** Each bash invocation is a fresh subshell; persist anything you want to keep.
+10. **AzDO API: anonymous only.** Stay on `_apis/build/...`. Never call `_apis/test/...` or `vstmr.dev.azure.com` (both redirect to sign-in).
+11. **Mention people sparingly and never spam teams.** See Step 4 author-attribution gates and Step 6 mention rules. They apply to PR bodies and comments alike. Render `@dotnet/<team>` handles as inline code, never as live mentions.
+
+## What this run must accomplish
+
+For every open `[ci-scan]` KBE in scope, converge on exactly one artifact:
+
+| Artifact | When | Same run? |
+|---|---|---|
+| Confident draft `[ci-fix]` fix PR | A small, validated fix removes the failure | Yes |
+| Help-wanted draft `[ci-fix]` PR | A plausible candidate change exists but is unvalidated or out of small-fix bounds; ask for help | Yes |
+| `ci-fix` loop-in comment on the KBE | No code change is producible at all (JIT/GC codegen, security/API, infra); loop in author + owners | Yes (once per KBE, ever) |
+| Recorded skip | Already handled, ambiguous, stale, or no signature | n/a |
+
+## Step-by-step
+
+Walk the steps in order. Do not skip. Stop at Step 7.
+
+### Step 1 — Orient
+
+Read once at start:
+
+- `.github/workflows/shared/create-kbe.instructions.md` — for the KBE body shape you will parse (`<a id="new-kbe-template"></a>` / `## New-KBE template`; the `Build error leg or test failing: <leg>-<assembly-or-test>` line carries the failing leg and test/assembly).
+- `docs/area-owners.md` — the area-label → owners mapping you use for hand-off mentions.
+- The skill matching the KBE's pipeline/area (routing table in Step 5.1). Skills live under `.github/skills/`.
+
+### Step 2 — Enumerate open KBEs
+
+List open KBE issues this workflow is responsible for. Use the `github` MCP `search_issues` (integrity-gated; `[Filtered]` results are skipped — record the count, do not chase them):
+
+- `repo:dotnet/runtime is:issue is:open label:"Known Build Error" in:title "[ci-scan]" updated:>=<today-30d>`
+
+For each result, read the body + latest comments through the `github` MCP (NOT `gh`, so the integrity gate applies). Extract:
+
+- The failing leg + test/assembly from the `Build error leg or test failing:` line.
+- The `Build:` link (AzDO build) and any `First build it occurred` commit/sha.
+- The applied `area-*` label (added by `.github/workflows/labeler-predict-issues.yml`). If no `area-*` label is present yet, record `-> skipped: not yet area-labeled` and let a later run revisit — owner attribution depends on it.
+
+**Freshness gate.** Skip any KBE created less than 60 minutes ago (`-> skipped: KBE too fresh, defer to next run`). The scanner and labeler run asynchronously; acting before the labeler has attached the `area-*` label produces mis-attributed hand-offs.
+
+### Step 3 — Existing-artifact dedup (search live GitHub, every KBE)
+
+Before doing any analysis work, confirm nothing already handles this KBE. Use the `github` MCP search tools:
+
+1. **Open fix PR already exists** — `repo:dotnet/runtime is:pr is:open in:title "[ci-fix]" "#<kbe>"` OR body contains `Linked KBE: #<kbe>`. If found -> `-> skipped: open fix PR #<n> already exists`.
+2. **Merged fix PR exists** — `repo:dotnet/runtime is:pr is:merged "Linked KBE: #<kbe>"`. If found, the KBE is likely already fixed -> `-> skipped: fix PR #<n> already merged; KBE may be stale`.
+3. **Closed-unmerged fix PR within 30d** — `repo:dotnet/runtime is:pr is:closed -is:merged "Linked KBE: #<kbe>" closed:>=<today-30d>`. If found, do NOT re-open the same fix unless you have a clearly different change. Record `-> skipped: prior fix PR #<n> closed without merge within 30d`.
+4. **A human (non-`[ci-fix]`) PR already references the KBE** — `repo:dotnet/runtime is:pr is:open "#<kbe>"`. If a maintainer is already fixing it -> `-> skipped: human PR #<n> already addressing`.
+5. **Author already engaged on the KBE.** From the KBE comments you read in Step 2, if any `MEMBER`/`OWNER` comment expresses active investigation or fix-forward intent (case-insensitive any of: `i'm fixing`, `i am fixing`, `investigating`, `will investigate`, `looking into`, `root cause`, `fix forward`, `fix-forward`, `landing in #`, `wait for #`, `pr is up`, `working on`), do NOT duplicate their work -> `-> skipped: author already engaged on #<kbe>`.
+6. **Prior hand-off comment** — if the KBE already carries a comment containing the marker `<!-- ci-fix:handoff -->`, a hand-off was already posted; you may still emit a fix PR this run if you have one, but you may NOT post a second comment (Hard rule 5).
+
+Persist each KBE's dedup verdict to `/tmp/gh-aw/agent/dedup/<kbe>.txt` so later steps don't re-query.
+
+### Step 4 — Root-cause analysis (read-only)
+
+For each surviving KBE, locate the failure and a likely cause.
+
+1. **Reproduce the signature.** From the `Build:` link, walk the AzDO timeline (`/builds/{id}/timeline?api-version=7.1`, reconstruct via `parentId`), find the failing task/Helix work item, and `curl -s "$log_url" | tee /tmp/gh-aw/agent/failure_<kbe>.log`. Confirm the KBE's `Error Message` substring actually appears in the log. If it does not, the KBE may be stale or already fixed -> `-> skipped: signature no longer reproduces in cited build`.
+2. **Locate the failing test/source.** From the test name or compile error, find the owning file(s) at `HEAD`. Read them. For build breaks, read the failing compile unit and the cited error code/line.
+3. **Identify the regression-introducing change (attribution gates).** Prefer the *first-bad-commit* range over raw `git blame`:
+   - Anchor on the KBE's `First build it occurred` commit/date. `git log --oneline --since=<a few days before first-occurrence> -- <failing file>` to find candidate PRs that touched the failing file/function/test before the first failing build.
+   - **Exclude** formatting-only, bulk-rename, file-move, dependency-bump, container-digest, and bot/codeflow commits (authors like `dotnet-maestro[bot]`, `github-actions[bot]`, codeflow merges) unless clearly causal.
+   - Require **>= 2 evidence points** before attributing to an author: (a) the failure first appears after their merge, (b) their change touched the failing file/function/test, (c) the change is topically related to the failure (same API/area). 
+   - If confidence is high, record at most ONE likely author handle. If confidence is low, record the candidate as a "possible related PR" link with NO author handle.
+
+### Step 5 — Decide: confident fix, help-wanted PR, or loop-in comment
+
+#### Step 5.1 — Load the matching skill
+
+| KBE pipeline / area | Skill | Fix policy |
+|---|---|---|
+| Mobile (ios/tvos/maccatalyst/android/wasm/wasi) | `mobile-platforms/SKILL.md` | Small test/csproj/condition fixes in bounds are fair game. |
+| JIT / GC / PGO stress (codegen) | `jit-regression-test/SKILL.md`; `ci-pipeline-monitor/SKILL.md` | JIT/GC product fixes are OUT of bounds for any PR — no safe diff is producible, so loop in JIT/GC owners with a comment. |
+| `System.Net.*` | `system-net-review/SKILL.md` | In bounds only if it satisfies Step 5.2. |
+| `Microsoft.Extensions.*` | `extensions-review/SKILL.md` | In bounds only if it satisfies Step 5.2. |
+| NativeAOT outer loop | check `eng/testing/tests.*aot*.targets` + the test `.csproj` | In bounds only if it satisfies Step 5.2. |
+| Generic | `ci-pipeline-monitor/SKILL.md` | In bounds only if it satisfies Step 5.2. |
+
+#### Step 5.2 — Attempt a fix, then classify confidence
+
+Always try to produce a real candidate change first. Read every file you would modify at `HEAD`, work out the minimal correct change (e.g. wrong expected value in a test, missing `using`, wrong cast, missing `#if`, off-by-one in test setup, a missing platform guard that *enables* correct behavior rather than disabling the test), and stage it. If the change reduces to "do what the source already does", there is nothing to fix -> record `-> skipped: candidate fix already present in source`.
+
+Once you have a candidate diff, classify it:
+
+**Confident (Branch FIX, Step 5.3)** — ALL of:
+- <= 20 changed lines, single file (test or product), non-public-API, non-JIT-codegen, non-GC, non-threading, non-security.
+- The fix is a genuine correction and the failing test or compile error directly verifies it.
+- You build-validated it (or can within this run).
+
+**Not confident but a candidate diff exists (Branch HELP, Step 5.4)** — any of:
+- The change is plausible but you could not build-validate it in the environment.
+- The correct fix exceeds the small-fix bounds (multi-file, > 20 lines, or touches a riskier area) yet you can still express an honest best-effort attempt.
+- You are unsure the change is the right one and want a human to confirm.
+
+**No candidate diff is producible (Branch COMMENT, Step 5.5)** — JIT/GC codegen you must not touch, a security/API design decision, or a non-code/infra failure. Only here do you fall back to a comment.
+
+#### Step 5.3 — Emit a confident fix PR (Branch FIX)
+
+Branch from `origin/main`. Stage only the files you change with `git add <specific path>` (never `git add -A`); verify with `git diff --name-only --cached`.
+
+**Validation contract.** Build-validate the change. For libraries: `dotnet build` the affected test project (and run the single failing test if feasible). Record the exact command and its result. If you ultimately cannot validate within the environment, this is no longer a confident fix — drop to Branch HELP (Step 5.4).
+
+Emit one `create_pull_request` using the Fix-PR template (Templates section). The PR MUST link the KBE (`Linked KBE: #<n>`) and carry the artifact marker block (`Artifact kind: fix`). Do not apply any label other than `agentic-workflows`. Do NOT add `area-*` labels — the labeler owns area triage.
+
+#### Step 5.4 — Emit a help-wanted PR (Branch HELP)
+
+You have a real candidate change but cannot stand fully behind it. Open it anyway so reviewers have something concrete to react to, instead of a bare comment.
+
+Branch from `origin/main`. Stage only the files you change with `git add <specific path>`; verify with `git diff --name-only --cached`. The diff MUST be a genuine attempt at the fix — **never** a test-disable, `[ActiveIssue]`, or csproj exclusion (that is muting, Hard rule 3).
+
+Run whatever validation you can and record the exact command + result (including "not run because <reason>"). Emit one `create_pull_request` using the Help-wanted-PR template. The title MUST make the ask visible (e.g. `[ci-fix] Needs review: <short description> (refs #<kbe>)`). The body MUST link the KBE (`Linked KBE: #<n>`), carry `Artifact kind: help`, state exactly what is unverified, and loop in the likely author + area owners under a non-accusatory "Help wanted" heading (Step 6 mention rules apply). Keep it draft.
+
+#### Step 5.5 — Emit a loop-in comment (Branch COMMENT, last resort)
+
+Only when no candidate diff is producible at all. Emit one `add_comment` on the KBE using the Loop-in comment template. This contains your root-cause analysis, the suspected regressing PR (if any), and a "Suggested reviewers / area contacts" section.
+
+Respect Hard rule 5 (at most one loop-in comment per KBE, ever) — re-check the `<!-- ci-fix:handoff -->` marker immediately before emitting.
+
+### Step 6 — Mention rules (apply to help-wanted PR bodies and loop-in comments)
+
+- Live-mention **at most one** individual regression author, and only when Step 4 reached high confidence. Otherwise write "Possible related PR: dotnet/runtime#<n>" with no `@`.
+- Live-mention **at most one or two** individual area owners from `docs/area-owners.md` for the KBE's `area-*` label.
+- **Never live-mention a GitHub team.** When an owner entry is a team handle (`@dotnet/<team>`), render it as inline code `` `@dotnet/<team>` `` so it does not notify the whole team.
+- Put all contacts under a clearly non-accusatory heading: `## Suggested reviewers / area contacts`. Frame as "loop-in for triage", not blame.
+- Never mention bots, `dotnet-maestro`, or `github-actions`.
+
+### Step 7 — Per-KBE tally + end-of-run summary
+
+Per KBE, append one outcome line to `/tmp/gh-aw/agent/coverage.txt`:
+
+```
+#<kbe>  <outcome>  <reason>
+```
+
+`<outcome>` is one of: `fix-PR #aw_<id>` (confident), `help-PR #aw_<id>` (needs review), `loopin-comment #<kbe>`, `skipped: <reason>`.
+
+Recognized skip reasons (reuse these phrasings so the feedback workflow's aggregation stays stable): `not yet area-labeled`, `KBE too fresh, defer to next run`, `open fix PR #<n> already exists`, `fix PR #<n> already merged; KBE may be stale`, `prior fix PR #<n> closed without merge within 30d`, `human PR #<n> already addressing`, `author already engaged on #<kbe>`, `loop-in comment already posted`, `signature no longer reproduces in cited build`, `candidate fix already present in source`, `no producible diff (JIT/GC/security/API/infra) — comment`, `cap reached`, `integrity-filtered candidate, needs human review`. The list is non-exhaustive but additions SHOULD reuse one of these phrasings.
+
+At end of run, print this table to the agent log:
+
+```
+| kbe | area | outcome | reason |
+```
+
+## Output markers
+
+Every PR body and every loop-in comment MUST begin with this marker block (the feedback workflow greps it to separate confident-fix, help-wanted, and comment artifacts and to dedup):
+
+```
+Workflow artifact: ci-fix
+Artifact kind: fix        # "fix" = confident PR, "help" = help-wanted PR, "handoff" = loop-in comment
+Linked KBE: #<n>
+```
+
+Loop-in comments MUST additionally include the HTML marker `<!-- ci-fix:handoff -->` somewhere in the body (used by the one-comment-per-KBE dedup in Step 3.6 / Hard rule 5).
+
+## Templates
+
+### Template: Fix-PR body (Branch FIX — confident)
+
+Title: `[ci-fix] Fix <short description of the failure> (refs #<kbe>)`.
+
+````markdown
+Workflow artifact: ci-fix
+Artifact kind: fix
+Linked KBE: #<n>
+
+## Root cause
+<what fails and why; cite the failing log line and the source location>
+
+## Fix
+<what this change does and why it is the correct, minimal correction — not a mute>
+
+## Validation
+- Command: `<exact dotnet build / test command>`
+- Result: <passed | failed | not run because <reason>>
+- Why the failing test/log validates this fix: <one or two sentences>
+
+## Evidence
+- Failing build: <AzDO link>
+- First build it occurred: <commit/sha + UTC timestamp> (computed within the scanned window; may not be the true origin)
+- Suspected regressing change: <dotnet/runtime#<n> | none identified>
+
+---
+Filed by [`ci-failure-fix`](https://github.com/dotnet/runtime/blob/main/.github/workflows/ci-failure-fix.md), which attempts validated fixes for `[ci-scan]` Known Build Errors and otherwise loops in owners. Comment here or on the workflow file to suggest changes; [`ci-failure-scan-feedback`](https://github.com/dotnet/runtime/blob/main/.github/workflows/ci-failure-scan-feedback.md) reads in-scope feedback daily and opens (or updates) a PR with prompt edits.
+````
+
+Keep the diff <= 20 lines, single file. Never stage a test-disabling change.
+
+### Template: Help-wanted-PR body (Branch HELP — not confident)
+
+Title: `[ci-fix] Needs review: <short description of the failure> (refs #<kbe>)`.
+
+````markdown
+Workflow artifact: ci-fix
+Artifact kind: help
+Linked KBE: #<n>
+
+> [!NOTE]
+> This is an AI/Copilot-generated **best-effort** fix attempt that I could not fully validate. It is a starting point for a maintainer, not a finished change. Please review the analysis below before merging.
+
+## Root cause (best analysis)
+<what fails, the failing log line, the source location, and the most likely cause>
+
+## Attempted fix
+<what this change does and the reasoning behind it>
+
+## What is unverified / where I need help
+- <e.g. could not build-validate because <reason> | unsure this is the correct layer to fix | change exceeds safe automated bounds (multi-file / risky area)>
+- <the specific question a reviewer should answer>
+
+## Validation
+- Command: `<exact dotnet build / test command, or "not run because <reason>">`
+- Result: <passed | failed | not run>
+
+## Evidence
+- Failing build: <AzDO link>
+- First build it occurred: <commit/sha + UTC timestamp> (computed within the scanned window; may not be the true origin)
+- Suspected regressing change: <dotnet/runtime#<n> | none identified with sufficient confidence>
+
+## Help wanted
+- Likely author: <@handle if high-confidence, else omit>
+- Area owners (`area-<x>`): <@individual-owner>, `@dotnet/<team>`
+
+---
+Filed by [`ci-failure-fix`](https://github.com/dotnet/runtime/blob/main/.github/workflows/ci-failure-fix.md). Comment here or on the workflow file to suggest changes; [`ci-failure-scan-feedback`](https://github.com/dotnet/runtime/blob/main/.github/workflows/ci-failure-scan-feedback.md) reads in-scope feedback daily and opens (or updates) a PR with prompt edits.
+````
+
+### Template: Loop-in comment body (Branch COMMENT — last resort)
+
+````markdown
+Workflow artifact: ci-fix
+Artifact kind: handoff
+Linked KBE: #<n>
+<!-- ci-fix:handoff -->
+
+> [!NOTE]
+> AI/Copilot-generated triage note.
+
+This Known Build Error has no producible automated code change (reason: <JIT/GC codegen — must not be auto-fixed | security/API design decision | non-code/infra failure>), so I could not open even a best-effort PR. Looping in owners so it can be fixed forward rather than muted.
+
+## Root cause (best analysis)
+<what fails, the failing log line, the source location, and the most likely cause>
+
+## Evidence
+- Failing build: <AzDO link>
+- First build it occurred: <commit/sha + UTC timestamp> (computed within the scanned window; may not be the true origin)
+- Possible related PR: <dotnet/runtime#<n> | none identified with sufficient confidence>
+
+## Suggested reviewers / area contacts
+- Likely author: <@handle if high-confidence, else omit>
+- Area owners (`area-<x>`): <@individual-owner>, `@dotnet/<team>`
+
+<one sentence: what a fix would likely involve, so a human can pick it up quickly>
+````
+
+## Environment constraints
+
+These look like permission errors but are physical (identical to `ci-failure-scan`).
+
+- **Pre-bind every URL to a shell variable on its own line, then `curl -s "$url"`.** Inline URLs with `?` or `&` are rejected as "Permission denied". Working pattern:
+
+  ```bash
+  url='https://dev.azure.com/dnceng-public/public/_apis/build/builds/12345/timeline?api-version=7.1'
+  curl -s "$url" | jq '.' | tee /tmp/gh-aw/agent/timeline.json
+  ```
+
+  Do NOT retry an inline URL hoping the rejection clears. Switch to the variable pattern immediately.
+
+- **No `>` or `-o` redirection.** Use `| tee /path/to/file`.
+- **No `$(...)` or `${var@P}`.** Compose via `xargs -I{}` or by reading files inline.
+- **OData `$top` must be encoded as `%24top` in URLs.**
+- **Each bash call runs in a fresh subshell.** Persist state to `/tmp/gh-aw/agent/<file>`.
+- **`dotnet` is available for build validation**, but a full baseline build is slow; prefer building only the single affected test project. If the build cannot complete in time, the fix is no longer "confident" — open it as a help-wanted PR (Branch HELP) marked unvalidated.
+
+## Output discipline
+
+- One KBE = one outcome line in `/tmp/gh-aw/agent/coverage.txt`.
+- Never mute, skip, or disable a test. If that is the only "fix" available, open a help-wanted PR with a non-disabling attempt, or (if no diff is possible) a loop-in comment.
+- Always prefer a PR (confident or help-wanted) over a comment; the comment is a last resort.
+- At most one open `[ci-fix]` PR and one loop-in comment per KBE, ever.
+- Don't propose alternative workflow designs. The structure here is the workflow.
+- Don't add `area-*` labels — the labeler owns area triage.
+- The final agent log MUST include the Step 7 summary table.

--- a/.github/workflows/ci-failure-scan-feedback.lock.yml
+++ b/.github/workflows/ci-failure-scan-feedback.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"2e1c800f18e97303502871201083b668124fa7908f8eb8291f65226193f7283a","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c8ad6bdb06c2dbd13759c732a03b215c6917d681b1b062396e09441d41ac85da","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","COPILOT_PAT_0","COPILOT_PAT_1","COPILOT_PAT_2","COPILOT_PAT_3","COPILOT_PAT_4","COPILOT_PAT_5","COPILOT_PAT_6","COPILOT_PAT_7","COPILOT_PAT_8","COPILOT_PAT_9","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Periodic tick that reads the latest ci-failure-scan runs and maintainer feedback on the issues/PRs it produced, scores them against a quality rubric, and proposes targeted edits to ci-failure-scan.md as a single draft PR.
+# Periodic tick that reads the latest ci-failure-scan and ci-failure-fix runs and maintainer feedback on the issues/PRs/comments they produce, scores them against a quality rubric, and proposes targeted edits to ci-failure-scan.md and/or ci-failure-fix.md as a single draft PR. Maintains the KPI tracker with separate scanner and fixer metrics.
 #
 # Resolved workflow manifest:
 #   Imports:
@@ -208,24 +208,24 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF'
+          cat << 'GH_AW_PROMPT_b4a6cb8c45407f3f_EOF'
           <system>
-          GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF
+          GH_AW_PROMPT_b4a6cb8c45407f3f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF'
+          cat << 'GH_AW_PROMPT_b4a6cb8c45407f3f_EOF'
           <safe-output-tools>
           Tools: create_issue, update_issue, create_pull_request, update_pull_request, push_to_pull_request_branch, missing_tool, missing_data, noop
-          GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF
+          GH_AW_PROMPT_b4a6cb8c45407f3f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF'
+          cat << 'GH_AW_PROMPT_b4a6cb8c45407f3f_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF
+          GH_AW_PROMPT_b4a6cb8c45407f3f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF'
+          cat << 'GH_AW_PROMPT_b4a6cb8c45407f3f_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -257,12 +257,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF
+          GH_AW_PROMPT_b4a6cb8c45407f3f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF'
+          cat << 'GH_AW_PROMPT_b4a6cb8c45407f3f_EOF'
           </system>
           {{#runtime-import .github/workflows/ci-failure-scan-feedback.md}}
-          GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF
+          GH_AW_PROMPT_b4a6cb8c45407f3f_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -456,9 +456,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4c60e9f8dfc33010_EOF'
-          {"create_issue":{"allowed_labels":["agentic-workflows"],"labels":["agentic-workflows"],"max":1},"create_pull_request":{"allowed_files":[".github/workflows/ci-failure-scan.md"],"draft":true,"labels":["agentic-workflows"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_dot_folder_excludes":[".github/"],"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"blocked","title_prefix":"[ci-scan-feedback] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_to_pull_request_branch":{"allowed_files":[".github/workflows/ci-failure-scan.md"],"if_no_changes":"warn","max":1,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_dot_folder_excludes":[".github/"],"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"blocked"},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1,"target":"*"},"update_pull_request":{"allow_body":true,"allow_title":true,"max":1,"update_branch":false}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_4c60e9f8dfc33010_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_56c983172df30239_EOF'
+          {"create_issue":{"allowed_labels":["agentic-workflows"],"labels":["agentic-workflows"],"max":1},"create_pull_request":{"allowed_files":[".github/workflows/ci-failure-scan.md",".github/workflows/ci-failure-fix.md"],"draft":true,"labels":["agentic-workflows"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_dot_folder_excludes":[".github/"],"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"blocked","title_prefix":"[ci-scan-feedback] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_to_pull_request_branch":{"allowed_files":[".github/workflows/ci-failure-scan.md",".github/workflows/ci-failure-fix.md"],"if_no_changes":"warn","max":1,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_dot_folder_excludes":[".github/"],"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"blocked"},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1,"target":"*"},"update_pull_request":{"allow_body":true,"allow_title":true,"max":1,"update_branch":false}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_56c983172df30239_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -812,7 +812,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_b45f93710d9b2073_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_06d2611b97f6444f_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -856,7 +856,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_b45f93710d9b2073_EOF
+          GH_AW_MCP_CONFIG_06d2611b97f6444f_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1274,27 +1274,9 @@ jobs:
             await main();
 
   detection:
-    # ###############################################################
-    # MANUAL PATCH: `detection` needs `pat_pool`
-    # ---------------------------------------------------------------
-    # `gh aw compile` only infers PAT-pool dependency for the `agent`
-    # job. Without `pat_pool` listed here, every secret/case() lookup
-    # in this job that consults `needs.pat_pool.outputs.pat_number`
-    # collapses to '', the `COPILOT_GITHUB_TOKEN` case() expression
-    # falls through to an empty/stale token, the api-proxy returns
-    # HTTP 400, the threat-detection parser fails, and gh-aw stamps a
-    # "Security scanning requires review" CAUTION banner on every
-    # issue/PR the agent produces.
-    #
-    # Re-add `- pat_pool` (and this comment) after every recompile.
-    # Tracked upstream by gh-aw issue #30232 — engine.env-based needs
-    # inference was fixed for the `agent` job in v0.71.5 but the fix
-    # has not been generalised to `detection`.
-    # ###############################################################
     needs:
       - activation
       - agent
-      - pat_pool
     if: >
       always() && needs.agent.result != 'skipped' && (needs.agent.outputs.output_types != '' || needs.agent.outputs.has_patch == 'true')
     runs-on: ubuntu-latest
@@ -1381,7 +1363,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           WORKFLOW_NAME: "CI Outer-Loop Failure Scanner — Feedback"
-          WORKFLOW_DESCRIPTION: "Periodic tick that reads the latest ci-failure-scan runs and maintainer feedback on the issues/PRs it produced, scores them against a quality rubric, and proposes targeted edits to ci-failure-scan.md as a single draft PR."
+          WORKFLOW_DESCRIPTION: "Periodic tick that reads the latest ci-failure-scan and ci-failure-fix runs and maintainer feedback on the issues/PRs/comments they produce, scores them against a quality rubric, and proposes targeted edits to ci-failure-scan.md and/or ci-failure-fix.md as a single draft PR. Maintains the KPI tracker with separate scanner and fixer metrics."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1691,7 +1673,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"allowed_labels\":[\"agentic-workflows\"],\"labels\":[\"agentic-workflows\"],\"max\":1},\"create_pull_request\":{\"allowed_files\":[\".github/workflows/ci-failure-scan.md\"],\"draft\":true,\"labels\":[\"agentic-workflows\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_dot_folder_excludes\":[\".github/\"],\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"blocked\",\"title_prefix\":\"[ci-scan-feedback] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"push_to_pull_request_branch\":{\"allowed_files\":[\".github/workflows/ci-failure-scan.md\"],\"if_no_changes\":\"warn\",\"max\":1,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_dot_folder_excludes\":[\".github/\"],\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"blocked\"},\"report_incomplete\":{},\"update_issue\":{\"allow_body\":true,\"max\":1,\"target\":\"*\"},\"update_pull_request\":{\"allow_body\":true,\"allow_title\":true,\"max\":1,\"update_branch\":false}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"allowed_labels\":[\"agentic-workflows\"],\"labels\":[\"agentic-workflows\"],\"max\":1},\"create_pull_request\":{\"allowed_files\":[\".github/workflows/ci-failure-scan.md\",\".github/workflows/ci-failure-fix.md\"],\"draft\":true,\"labels\":[\"agentic-workflows\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_dot_folder_excludes\":[\".github/\"],\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"blocked\",\"title_prefix\":\"[ci-scan-feedback] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"push_to_pull_request_branch\":{\"allowed_files\":[\".github/workflows/ci-failure-scan.md\",\".github/workflows/ci-failure-fix.md\"],\"if_no_changes\":\"warn\",\"max\":1,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_dot_folder_excludes\":[\".github/\"],\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"blocked\"},\"report_incomplete\":{},\"update_issue\":{\"allow_body\":true,\"max\":1,\"target\":\"*\"},\"update_pull_request\":{\"allow_body\":true,\"allow_title\":true,\"max\":1,\"update_branch\":false}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-failure-scan-feedback.md
+++ b/.github/workflows/ci-failure-scan-feedback.md
@@ -1,6 +1,6 @@
 ---
 name: "CI Outer-Loop Failure Scanner — Feedback"
-description: "Periodic tick that reads the latest ci-failure-scan runs and maintainer feedback on the issues/PRs it produced, scores them against a quality rubric, and proposes targeted edits to ci-failure-scan.md as a single draft PR."
+description: "Periodic tick that reads the latest ci-failure-scan and ci-failure-fix runs and maintainer feedback on the issues/PRs/comments they produce, scores them against a quality rubric, and proposes targeted edits to ci-failure-scan.md and/or ci-failure-fix.md as a single draft PR. Maintains the KPI tracker with separate scanner and fixer metrics."
 
 permissions:
   contents: read
@@ -52,6 +52,7 @@ safe-outputs:
     max: 1
     allowed-files:
       - ".github/workflows/ci-failure-scan.md"
+      - ".github/workflows/ci-failure-fix.md"
     protected-files:
       policy: blocked
       exclude:
@@ -62,6 +63,7 @@ safe-outputs:
     max: 1
     allowed-files:
       - ".github/workflows/ci-failure-scan.md"
+      - ".github/workflows/ci-failure-fix.md"
     protected-files:
       policy: blocked
       exclude:
@@ -88,48 +90,69 @@ network:
 
 # CI Failure Scanner — Feedback
 
-You evaluate the [`CI Outer-Loop Failure Scanner`](ci-failure-scan.md), maintain a single KPI tracker issue with a running window of metrics, and propose targeted edits to its prompt so the next run produces tighter, more actionable artifacts. You run read-only; the only write paths are against `.github/workflows/ci-failure-scan.md` and the tracker issue body.
+You evaluate two workflows — the [`CI Outer-Loop Failure Scanner`](ci-failure-scan.md) (detection: files KBEs) and the [`CI Outer-Loop Failure Fixer`](ci-failure-fix.md) (mitigation: opens confident `[ci-fix]` fix PRs, opens help-wanted `[ci-fix]` PRs when a fix is attempted but unverified, or posts a loop-in comment on the KBE when no diff is producible) — maintain a single KPI tracker issue with a running window of metrics, and propose targeted edits to either prompt so the next runs produce tighter, more actionable artifacts. You run read-only; the only write paths are against `.github/workflows/ci-failure-scan.md`, `.github/workflows/ci-failure-fix.md`, and the tracker issue body.
 
-Hard rules: no comments on issues/PRs, no edits outside `.github/workflows/ci-failure-scan.md`, max 1 PR + 1 tracker issue open at a time. Reading issue/PR bodies and comments (the user-supplied content the integrity gate exists to filter) MUST go through the `github` MCP tool with `min-integrity: approved`; `[Filtered]` results are skipped (record the count, do not chase them). `gh` calls are allowed for workflow-run metadata (`gh api .../actions/...`, `gh run view --log`) and for enumerating this workflow's own artifacts (finding the `[ci-scan-feedback]` PR/tracker by title or repository-owned label), but NOT for reading maintainer-supplied content — do not use `gh issue view`, `gh pr view`, or `gh api /repos/.../comments` to substitute for the integrity-gated reads.
+Hard rules: no comments on issues/PRs, no edits outside the two prompt files above, max 1 PR + 1 tracker issue open at a time. Reading issue/PR/comment bodies (the user-supplied content the integrity gate exists to filter) MUST go through the `github` MCP tool with `min-integrity: approved`; `[Filtered]` results are skipped (record the count, do not chase them). `gh` calls are allowed for workflow-run metadata (`gh api .../actions/...`, `gh run view --log`) and for enumerating this workflow's own artifacts (finding the `[ci-scan-feedback]` PR/tracker by title or repository-owned label), but NOT for reading maintainer-supplied content — do not use `gh issue view`, `gh pr view`, or `gh api /repos/.../comments` to substitute for the integrity-gated reads.
+
+The two workflows are evaluated on separate axes; do NOT merge their quality numbers. The scanner is judged on KBE precision (right classification, specific signature, valid JSON). The fixer is judged on fix-PR usefulness, help-wanted-PR honesty (a real attempt + a clear ask, never a disguised mute), and loop-in-comment quality. A `[ci-scan]` KBE closed wrong and a `[ci-fix]` PR closed wrong are different failure modes with different fixes. The fixer always prefers a PR (confident or help-wanted) over a comment; a rising share of loop-in comments where a help-wanted PR was feasible is itself a fixer-quality signal.
 
 ## Steps
 
-1. Fetch the latest 10 runs of `ci-failure-scan.lock.yml`:
+1. Fetch the latest 10 runs of BOTH `ci-failure-scan.lock.yml` and `ci-failure-fix.lock.yml`:
 
    ```bash
-   gh api "/repos/dotnet/runtime/actions/workflows/ci-failure-scan.lock.yml/runs?per_page=10" \
-     | tee /tmp/gh-aw/agent/runs.json | jq -r '.workflow_runs[] | "\(.id) \(.conclusion) \(.head_branch) \(.event) \(.created_at) \(.html_url)"'
+   for wf in ci-failure-scan ci-failure-fix; do
+     gh api "/repos/dotnet/runtime/actions/workflows/${wf}.lock.yml/runs?per_page=10" \
+       | tee /tmp/gh-aw/agent/runs_${wf}.json \
+       | jq -r --arg wf "$wf" '.workflow_runs[] | "\($wf) \(.id) \(.conclusion) \(.head_branch) \(.event) \(.created_at) \(.html_url)"'
+   done
    ```
 
-2. For the latest 2 runs, list the issues/PRs they produced and download the agent log to extract the final tally line emitted by Step 6 of `ci-failure-scan.md`. Extract ONLY the tally table block (header + body rows, terminated by the first non-pipe line) — do NOT pipe arbitrary trailing log content through, since the scanner agent's log may contain quoted maintainer-supplied content that bypasses the integrity gate:
+   If `ci-failure-fix.lock.yml` has no runs yet (newly added workflow), record `ci-fix: no runs yet` and continue — the scanner half of this tick still runs.
+
+2. For the latest 2 runs of EACH workflow, list the issues/PRs/comments they produced and download the agent log to extract the final tally table emitted by Step 6 of `ci-failure-scan.md` (`| pipeline | ...`) or Step 7 of `ci-failure-fix.md` (`| kbe | area | outcome | reason |`). Extract ONLY the tally table block (header + body rows, terminated by the first non-pipe line) — do NOT pipe arbitrary trailing log content through, since the agent logs may contain quoted maintainer-supplied content that bypasses the integrity gate:
 
    ```bash
    gh run view <run-id> --log \
-     | awk '/^\| pipeline \|/{flag=1} flag && /^\|/{print; next} flag{exit}' \
+     | awk '/^\| pipeline \|/{flag=1} /^\| kbe \|/{flag=1} flag && /^\|/{print; next} flag{exit}' \
      | tee /tmp/gh-aw/agent/tally_<run-id>.txt
    ```
 
-3. Read in-scope feedback. Issues and PRs are in scope when EITHER the `agentic-workflows` label is present OR the title starts with `[ci-scan]`. For each in-scope item updated in the last 30 days, fetch body + all comments via the `github` MCP tool (NOT `gh`, per the hard rule above). Quote any maintainer comment matching: "too broad", "doesn't match", "duplicate", "wrong label", "JSON malformed", "fix-forward", "don't disable", "Known issue did not match", "should be supported", "wait for #".
+3. Read in-scope feedback. Issues, PRs, and comments are in scope when EITHER the `agentic-workflows` label is present OR the title starts with `[ci-scan]` or `[ci-fix]`. For each in-scope item updated in the last 30 days, fetch body + all comments via the `github` MCP tool (NOT `gh`, per the hard rule above). Quote any maintainer comment matching: "too broad", "doesn't match", "duplicate", "wrong label", "JSON malformed", "fix-forward", "don't disable", "Known issue did not match", "should be supported", "wait for #", "wrong fix", "this isn't the cause", "don't @ me", "wrong owner", "not my area".
 
    Discover candidates with the `github` tool's `search_issues` and `search_pull_requests` over both label and title scopes, applying the 30-day window via the search query itself:
 
    - `repo:dotnet/runtime is:issue label:agentic-workflows updated:>=<today-30d>`
    - `repo:dotnet/runtime is:issue in:title "[ci-scan]" updated:>=<today-30d>`
-   - `repo:dotnet/runtime is:pr label:agentic-workflows updated:>=<today-30d>`
    - `repo:dotnet/runtime is:pr in:title "[ci-scan]" updated:>=<today-30d>`
+   - `repo:dotnet/runtime is:pr in:title "[ci-fix]" updated:>=<today-30d>`
+   - `repo:dotnet/runtime is:pr label:agentic-workflows updated:>=<today-30d>`
 
-   Both the closed and open state buckets are in scope (closed items often carry the most informative feedback about why the artifact was rejected). For each result, read the body and comments via the `github` tool. When listing comments, request only the most recent 100 (one page at the MCP default size) — the 30-day `updated:>=...` window is the primary filter, and threads with >100 comments are vanishingly rare for `[ci-scan]` artifacts. If a result has >100 comments, fetch the latest page only; do NOT paginate further (older comments are out-of-scope by construction). Record `integrity-filtered: N` for any `[Filtered]` results and continue.
+   Both the closed and open state buckets are in scope (closed items often carry the most informative feedback about why the artifact was rejected). For each result, read the body and comments via the `github` tool. When listing comments, request only the most recent 100 (one page at the MCP default size) — the 30-day `updated:>=...` window is the primary filter, and threads with >100 comments are vanishingly rare for these artifacts. If a result has >100 comments, fetch the latest page only; do NOT paginate further (older comments are out-of-scope by construction). Record `integrity-filtered: N` for any `[Filtered]` results and continue.
 
-4. Score each artifact against the rubric:
+   `[ci-fix]` loop-in comments live on `[ci-scan]` KBE issues (marker `<!-- ci-fix:handoff -->`); when you read a KBE, also read the replies to any loop-in comment — a maintainer reply that the @-mentioned owner was wrong, or that the analysis was off, is a primary feedback signal. Help-wanted `[ci-fix]` PRs (`Artifact kind: help`) carry the same signal in their review threads: a maintainer reply that the attempt was on the wrong track, or that a comment would have sufficed, feeds the fixer's confidence calibration.
+
+4. Score each artifact against the rubric.
+
+   **Scanner artifacts (`[ci-scan]` KBE issues):**
 
    - Title is scoped to a single failure shape (not a list of pipelines).
-   - Classification matches the failure (KBE-eligible test/hang -> `Known Build Error`; build break -> KBE without test-disable; infra noise -> no issue at all).
+   - Classification matches the failure (KBE-eligible test/hang -> `Known Build Error`; build break -> KBE; infra noise -> no issue at all).
    - JSON block is valid: exactly one fenced `` ```json `` block, all four keys present, exactly one of `ErrorMessage`/`ErrorPattern` non-empty.
    - Signature is specific: not a bare test/method name, not a generic exception/exit-code, not a phrase that also appears in `[PASS]`/`[SKIP]` lines of the same log.
    - For a sample of in-scope KBEs, cross-check the signature against the cited failing log (`gh run view <id> --log-failed | head -300` or the AzDO/Helix URL in the body) and flag PASS-line collisions or paraphrased signatures.
-   - Skip-reason vocabulary stability: any tally row using a `skipped:` reason NOT in the Step 6 'Recognized values' list in `ci-failure-scan.md` is flagged as `unknown-skip-reason: <verbatim string>`. The recognized values list is the source of truth; the feedback PR should propose adding new reasons there before they start appearing in tallies.
+   - Skip-reason vocabulary stability: any scanner tally row using a `skipped:` reason NOT in the Step 6 'Recognized values' list in `ci-failure-scan.md` is flagged as `unknown-skip-reason: <verbatim string>`.
 
-5. Translate each failure mode into a targeted edit to `.github/workflows/ci-failure-scan.md`. Prefer rule-shaped edits (tighten Step 4.2, extend Step 4.7's phrase list, add a Bad/Good row, narrow KBE check 7) over wholesale rewrites. Read the file first; reuse the existing voice and section structure.
+   **Fixer artifacts (`[ci-fix]` confident PRs, help-wanted PRs, and loop-in comments):**
+
+   - Carries the artifact marker block (`Workflow artifact: ci-fix`, `Artifact kind: fix|help|handoff`, `Linked KBE: #<n>`). Flag any missing marker.
+   - Confident fix PR (`kind: fix`): diff is small (<= 20 lines, single file), is a genuine fix (NOT a test-disable / `[ActiveIssue]` / `Skip` / `<*Incompatible>` — flag any muting as a hard violation), and the body states an explicit validation command + result.
+   - Help-wanted PR (`kind: help`): carries a real best-effort diff that is NOT a mute (flag any muting as a hard violation), an explicit "what is unverified / where I need help" section, and a loop-in of at most one likely author + 1–2 individual owners. A help-wanted PR closed without merge is NOT a quality miss by itself (it explicitly asked for help) — only flag it when a maintainer reply says the attempt was wrong-headed, a mute, or that no PR should have been opened. Flag a `kind: help` PR whose diff is actually validated and in bounds (it should have been `kind: fix`), and flag a loop-in comment that could clearly have been a help-wanted PR.
+   - PR linkage: `Linked KBE: #<n>` present and the KBE is real and open.
+   - Loop-in comment (`kind: handoff`): at most one per KBE (flag duplicates), contains a concrete root cause, mentions at most one likely author + 1–2 individual owners, and is justified (no producible diff). Flag live `@dotnet/<team>` team mentions (should be inline code) and flag mis-attributed authors called out by maintainer replies.
+   - Fixer skip-reason vocabulary: any fixer tally row using a `skipped:` reason NOT in the Step 7 'Recognized skip reasons' list in `ci-failure-fix.md` is flagged as `unknown-skip-reason: <verbatim string>`.
+
+5. Translate each failure mode into a targeted edit to the matching prompt file: scanner findings -> `.github/workflows/ci-failure-scan.md`; fixer findings -> `.github/workflows/ci-failure-fix.md`. Prefer rule-shaped edits (tighten a step, extend a keyword/phrase list, add a Bad/Good row, narrow a gate) over wholesale rewrites. Read the file first; reuse the existing voice and section structure. A single PR may edit both files when both have findings.
 
 6. Emit changes. Check for an existing open `[ci-scan-feedback]` PR first:
 
@@ -169,38 +192,52 @@ Hard rules: no comments on issues/PRs, no edits outside `.github/workflows/ci-fa
 
    The `/runs` endpoint does NOT accept `order=asc`; you MUST paginate and pick `min(created_at)`. Fall back to the workflow's `.created_at` only if no runs exist yet (first-ever invocation). Once the tracker exists, the cached marker is authoritative.
 
-   Collect the full universe of `[ci-scan]` issues and PRs (open + closed) since `window_start` via `gh search issues` / `gh search prs` with `created:>=<window_start>`. This produces a list of issue/PR numbers and metadata; do NOT read bodies with `gh`. Cache the list to `/tmp/gh-aw/agent/artifacts.json` so later sections do not re-query.
+   Collect the full universe of `[ci-scan]` and `[ci-fix]` issues and PRs (open + closed) since `window_start` via `gh search issues` / `gh search prs` with `created:>=<window_start>`. This produces a list of issue/PR numbers and metadata; do NOT read bodies with `gh`. Cache the list to `/tmp/gh-aw/agent/artifacts.json` so later sections do not re-query. Tag each cached row with its workflow: title starting `[ci-scan]` -> scanner; title starting `[ci-fix]` -> fixer.
 
    `gh search issues --json` and `gh search prs --json` already return `state`, `stateReason`, `labels`, `mergedAt`, `closedAt`, and `author` for each result; that metadata is sufficient for the activity and quality counts below. Only fetch through the integrity-gated `github` MCP when you actually need body or comment text.
 
-   For metrics that need MEMBER/OWNER comment content (rejection-keyword detection, re-file outage signal), fetch through the `github` MCP `issue_read get`, `pull_request_read get`, and the corresponding comments tools, one per item, respecting `min-integrity: approved`. Skip `[Filtered]` items.
+   For metrics that need MEMBER/OWNER comment content (rejection-keyword detection, re-file outage signal, hand-off engagement), fetch through the `github` MCP `issue_read get`, `pull_request_read get`, and the corresponding comments tools, one per item, respecting `min-integrity: approved`. Skip `[Filtered]` items.
 
-   Compute these KPIs. The shape below is deliberately small: raw counts, one quality ratio, a fixed set of outage signals. Do not re-introduce Wilson scoring, time-to-KBE, coverage ratios, or tally-extraction; they were dropped because they came back `n/a` most ticks and added noise.
+   Loop-in comments are `[ci-fix]` comments on `[ci-scan]` KBE issues carrying the marker `<!-- ci-fix:handoff -->`. Count them by reading KBE comments via the `github` MCP. A loop-in has "maintainer engagement" when a MEMBER/OWNER replied after it.
+
+   Compute these KPIs. The shape below is deliberately small: raw counts, two quality ratios (scanner and fixer, kept separate), a fixed set of outage signals. Do not re-introduce Wilson scoring, time-to-KBE, coverage ratios, or tally-extraction; they were dropped because they came back `n/a` most ticks and added noise.
 
    ### A) Activity (last 7d)
 
-   For each artifact type (issues, PRs), count:
+   Count, per artifact stream:
 
-   - `opened` — artifacts created in the last 7d.
-   - `closed_good` — issues closed in the last 7d with `state_reason: completed`; PRs merged in the last 7d.
-   - `closed_wrong` — issues closed in the last 7d with `state_reason` in `{not_planned, duplicate}`; PRs closed without merge in the last 7d.
+   - Scanner `[ci-scan]` KBE issues: `opened`, `closed_good` (closed `completed`), `closed_wrong` (closed `not_planned`/`duplicate`).
+   - Fixer `[ci-fix]` PRs: `opened`, `merged`, `closed_unmerged`. Sub-split by marker `Artifact kind`: `confident` (`kind: fix`) vs `help_wanted` (`kind: help`).
+   - Fixer loop-in comments: `posted` (count of new `<!-- ci-fix:handoff -->` comments), `engaged` (subset with a MEMBER/OWNER reply).
 
-   ### B) Quality (closure cohort, last 30d)
+   ### B) Scanner quality (closure cohort, last 30d)
 
-   The quality rate is closure-based, not creation-based: a wrong closure of an old item still counts against this period's quality. This avoids the cross-cohort denominator bug where rate could exceed 100% if computed against opens.
+   Closure-based, not creation-based: a wrong closure of an old KBE still counts against this period. Scope = `[ci-scan]` KBE issues only.
 
-   - `closed_good_30d = i_good_30d + p_merged_30d`.
-   - `closed_wrong_30d = i_wrong_30d + p_unmerged_30d`.
-   - `closed_30d = closed_good_30d + closed_wrong_30d`.
-   - `wrong_rate_30d = closed_wrong_30d / closed_30d`. Emit as `n/a` when `closed_30d < 10`.
-   - `complaints_30d` — count of MEMBER/OWNER comments on in-scope artifacts (open or closed) matching (case-insensitive): `don't disable`, `do not disable`, `do not mute`, `please don't`, `false positive`, `fix forward`, `fix-forward`, `investigation in progress`, `will investigate`, `stop filing`, `noise`, `not a real failure`, `flaky test`.
-   - `duplicates_30d` — issues closed in the last 30d with `state_reason: duplicate` OR carrying a `duplicate` label.
+   - `i_good_30d` — KBEs closed `completed` in the last 30d.
+   - `i_wrong_30d` — KBEs closed `not_planned`/`duplicate` in the last 30d.
+   - `scan_closed_30d = i_good_30d + i_wrong_30d`.
+   - `scan_wrong_rate_30d = i_wrong_30d / scan_closed_30d`. Emit as `n/a` when `scan_closed_30d < 10`.
+   - `complaints_30d` — count of MEMBER/OWNER comments on in-scope `[ci-scan]` artifacts (open or closed) matching (case-insensitive): `don't disable`, `do not disable`, `do not mute`, `please don't`, `false positive`, `fix forward`, `fix-forward`, `investigation in progress`, `will investigate`, `stop filing`, `noise`, `not a real failure`, `flaky test`.
+   - `duplicates_30d` — KBEs closed in the last 30d with `state_reason: duplicate` OR carrying a `duplicate` label.
 
-   ### C) Outage signals
+   ### C) Fixer quality (closure cohort, last 30d)
 
-   These reflect the health of the **CI being monitored**, not the scanner workflow itself. Each signal has a fixed threshold and renders as 🔴 when tripped, otherwise 🟢.
+   Scope = `[ci-fix]` PRs (both `kind: fix` and `kind: help`) and loop-in comments. Do NOT fold these into the scanner rate. A `[ci-fix]` PR closed without merge is NOT automatically "wrong" — a maintainer may have taken over or landed an equivalent fix, and a help-wanted PR explicitly invites a maintainer to close it — so it is reported but only the rejection-keyword subset counts as a quality miss.
 
-   Source data comes from the cached artifact list; `[ci-scan]` KBE issues are proxies for distinct stable failure signatures in CI. For each KBE issue, fetch the body via the `github` MCP and grep for the line `Build error leg or test failing: <value>` (this is the only place the KBE template carries leg information; older `Impact on platforms` lines are not present in templates emitted after #128440). The value is `<AzDO leg name>-<assembly or test name>` where the separator is the LAST `-` in the value: split on the last hyphen and treat the left side as the leg. Cache `(issue_number, leg)` rows to `/tmp/gh-aw/agent/artifact_legs.tsv`. The pipeline-outage signal counts distinct legs because the KBE body does not capture the AzDO pipeline definition id reliably; treat distinct legs as a conservative proxy for distinct pipelines.
+   - `fix_merged_30d` — `[ci-fix]` PRs merged in the last 30d.
+   - `fix_unmerged_30d` — `[ci-fix]` PRs closed without merge in the last 30d.
+   - `fix_rejected_30d` — subset of `fix_unmerged_30d` whose close carries a MEMBER/OWNER comment matching the section B keyword set OR `wrong fix`, `this isn't the cause`, `wrong owner`, `not my area`, `don't @ me`. A help-wanted PR closed with only neutral/thankful maintainer replies is NOT counted here.
+   - `fix_closed_30d = fix_merged_30d + fix_unmerged_30d`.
+   - `fix_reject_rate_30d = fix_rejected_30d / fix_closed_30d`. Emit `n/a` when `fix_closed_30d < 5`.
+   - `handoff_posted_30d`, `handoff_engaged_30d` — loop-in comments posted and those with a MEMBER/OWNER reply.
+   - `misattributions_30d` — loop-in comments or help-wanted PRs with a MEMBER/OWNER reply matching `wrong owner`, `not my area`, `don't @ me`, `wasn't me`, `not the cause`.
+
+   ### D) Outage signals
+
+   These reflect the health of the **CI being monitored**, not the scanner/fixer workflows. Each signal has a fixed threshold and renders as 🔴 when tripped, otherwise 🟢.
+
+   Source data comes from the cached artifact list; `[ci-scan]` KBE issues are proxies for distinct stable failure signatures in CI. For each KBE issue, fetch the body via the `github` MCP and grep for the line `Build error leg or test failing: <value>` (this is the only place the KBE template carries leg information). The value is `<AzDO leg name>-<assembly or test name>` where the separator is the LAST `-` in the value: split on the last hyphen and treat the left side as the leg. Cache `(issue_number, leg)` rows to `/tmp/gh-aw/agent/artifact_legs.tsv`. The pipeline-outage signal counts distinct legs because the KBE body does not capture the AzDO pipeline definition id reliably; treat distinct legs as a conservative proxy for distinct pipelines.
 
    | signal | source | threshold |
    |---|---|---|
@@ -208,34 +245,49 @@ Hard rules: no comments on issues/PRs, no edits outside `.github/workflows/ci-fa
    | Build-break spike | count of `[ci-scan] Build break:` issues created per 24h | >= 2 in any 24h window in the last 7d |
    | Multi-pipeline outage (distinct legs proxy) | distinct leg names (parsed per above) across KBEs created in the last 24h | >= 3 distinct legs |
    | KBE re-filed after maintainer close | for each `[ci-scan]` KBE issue opened in the last 7d, search `is:issue is:closed -is:open in:title "<test-name-stem>" closed:>=<14d-ago>` and check whether any closed predecessor exists with a MEMBER/OWNER comment matching the keyword set in section B | any in the last 7d |
-   | Wrong-closure rate | section B's `wrong_rate_30d` | >= 30% with `closed_30d >= 10` |
+   | Scanner wrong-closure rate | section B's `scan_wrong_rate_30d` | >= 30% with `scan_closed_30d >= 10` |
+   | Fixer rejection rate | section C's `fix_reject_rate_30d` | >= 30% with `fix_closed_30d >= 5` |
 
    Emit a body with this exact shape (regenerate every tick):
 
    ````markdown
    <!-- ci-scan-feedback:kpi-tracker -->
    <!-- ci-scan-feedback:window-start=<window_start> -->
-   Tracking quality of `[ci-scan]` issues and PRs since <window_start>. Updated every tick of [ci-failure-scan-feedback.lock.yml](https://github.com/dotnet/runtime/blob/main/.github/workflows/ci-failure-scan-feedback.lock.yml). To raise a concern, comment here or on any `[ci-scan]` issue/PR; the next tick reads in-scope feedback and either opens a `[ci-scan-feedback]` PR with prompt edits or pushes to the existing one.
+   Tracking quality of `[ci-scan]` (detection) and `[ci-fix]` (mitigation) issues, PRs, and loop-in comments since <window_start>. Updated every tick of [ci-failure-scan-feedback.lock.yml](https://github.com/dotnet/runtime/blob/main/.github/workflows/ci-failure-scan-feedback.lock.yml). To raise a concern, comment here or on any `[ci-scan]`/`[ci-fix]` issue/PR; the next tick reads in-scope feedback and either opens a `[ci-scan-feedback]` PR with prompt edits or pushes to the existing one.
 
    ## Snapshot — <UTC timestamp>
 
    ### Activity (last 7d)
 
-   | artifact | opened | closed (good) | closed (wrong) |
+   | stream | opened | good | wrong/unmerged |
    |---|---|---|---|
-   | Issues | <i_op_7> | <i_good_7> | <i_wrong_7> |
-   | PRs | <p_op_7> | <p_merged_7> | <p_unmerged_7> |
+   | Scanner KBE issues | <i_op_7> | <i_good_7> | <i_wrong_7> |
+   | Fixer `[ci-fix]` PRs (confident) | <p_fix_op_7> | <p_fix_merged_7> | <p_fix_unmerged_7> |
+   | Fixer `[ci-fix]` PRs (help-wanted) | <p_help_op_7> | <p_help_merged_7> | <p_help_unmerged_7> |
+   | Fixer loop-in comments | <handoff_posted_7> | <handoff_engaged_7> engaged | — |
 
-   "closed (good)" = issues closed `completed`, PRs merged. "closed (wrong)" = issues closed `not_planned`/`duplicate`, PRs closed without merge.
+   "good" = KBEs closed `completed`, PRs merged, loop-ins with a maintainer reply. "wrong/unmerged" = KBEs closed `not_planned`/`duplicate`, PRs closed without merge (note: a help-wanted PR closed unmerged is expected, not necessarily a miss).
 
-   ### Quality (last 30d)
+   ### Scanner quality (last 30d)
 
    | metric | count | rate |
    |---|---|---|
-   | Total closures | <closed_30d> | — |
-   | Wrong closures | <closed_wrong_30d> | <wrong_rate_30d_pct or `n/a (<closed_30d><10)`> |
+   | KBE closures | <scan_closed_30d> | — |
+   | Wrong KBE closures | <i_wrong_30d> | <scan_wrong_rate_30d_pct or `n/a (<scan_closed_30d><10)`> |
    | Maintainer rejection comments | <complaints_30d> | — |
    | Duplicate KBEs | <duplicates_30d> | — |
+
+   ### Fixer quality (last 30d)
+
+   | metric | count | rate |
+   |---|---|---|
+   | Fix PR closures | <fix_closed_30d> | — |
+   | Fix PRs merged | <fix_merged_30d> | — |
+   | Fix PRs rejected (maintainer pushback) | <fix_rejected_30d> | <fix_reject_rate_30d_pct or `n/a (<fix_closed_30d><5)`> |
+   | Loop-in comments (posted / engaged) | <handoff_posted_30d> / <handoff_engaged_30d> | — |
+   | Loop-in / help-wanted mis-attributions | <misattributions_30d> | — |
+
+   If `ci-failure-fix.lock.yml` has no runs yet, render this table's counts as `0` and add the note `_Fixer not yet active._` below it.
 
    ### Outage signals (analyzed CI)
 
@@ -245,7 +297,8 @@ Hard rules: no comments on issues/PRs, no edits outside `.github/workflows/ci-fa
    | Build-break spike | >= 2 in any 24h | <bb_24h> | <bb_7d> | <icon> |
    | Multi-pipeline outage (distinct legs proxy) | >= 3 distinct legs in 24h | <legs_24h> distinct | <legs_peak_7d> distinct (peak day) | <icon> |
    | KBE re-filed after maintainer close | any in 7d | <refile_24h> | <refile_7d> | <icon> |
-   | Wrong-closure rate (30d) | >= 30% with `closed_30d >= 10` | — | <wrong_rate_30d_pct> | <icon> |
+   | Scanner wrong-closure rate (30d) | >= 30% with `scan_closed_30d >= 10` | — | <scan_wrong_rate_30d_pct> | <icon> |
+   | Fixer rejection rate (30d) | >= 30% with `fix_closed_30d >= 5` | — | <fix_reject_rate_30d_pct> | <icon> |
 
    For each signal at 🔴, emit one `details:` line **after** the Outage signals table (not inside it; markdown tables cannot carry sub-rows). Prefix each line with the signal name so it is unambiguous which row it explains. Example:
 
@@ -259,7 +312,8 @@ Hard rules: no comments on issues/PRs, no edits outside `.github/workflows/ci-fa
 
    Suppression rules:
 
-   - If `closed_30d < 10`, the Quality table's `rate` column reads `n/a (<n><10)` for `wrong_rate_30d`; all other rows still render with raw counts.
+   - If `scan_closed_30d < 10`, the Scanner quality table's `rate` reads `n/a (<n><10)` for the wrong-closure row; other rows still render raw counts.
+   - If `fix_closed_30d < 5`, the Fixer quality table's `rate` reads `n/a (<n><5)` for the rejection row.
    - Outage signals always render. An explicit 🟢 with no data still carries information.
    - Do NOT emit charts (mermaid or otherwise).
    - Do NOT emit historical weekly buckets. The body is a current snapshot.
@@ -268,10 +322,16 @@ Hard rules: no comments on issues/PRs, no edits outside `.github/workflows/ci-fa
 
 ## Output to agent log
 
-Print the rubric scorecard table to the agent log so the next tick can grep it:
+Print the rubric scorecards to the agent log so the next tick can grep them. Scanner artifacts:
 
 ```
 | run-id | artifact | title-scoped | classification | json-valid | signature-specific | log-cross-check | maintainer-feedback |
+```
+
+Fixer artifacts:
+
+```
+| run-id | artifact | kind | marker-present | small-validated-fix | no-muting | kbe-linked | mention-discipline | maintainer-feedback |
 ```
 
 One row per artifact scored. Skip rows where every column is `pass`. Append a final line `[Filtered] count: <n>` so out-of-integrity items are visible without being followed.

--- a/.github/workflows/ci-failure-scan.md
+++ b/.github/workflows/ci-failure-scan.md
@@ -1,6 +1,6 @@
 ---
 name: "CI Outer-Loop Failure Scanner"
-description: "Periodic scan of runtime-extra-platforms and outer-loop CI pipelines (JIT/GC stress, PGO, libraries-jitstress, etc.). Files Known Build Errors so failures are immediately ignorable in PR CI; opens companion skip PRs to remove the failure permanently after human review."
+description: "Periodic scan of runtime-extra-platforms and outer-loop CI pipelines (JIT/GC stress, PGO, libraries-jitstress, etc.). Files Known Build Errors so failures are immediately ignorable in PR CI. Detection only — mitigation (fix PRs and owner hand-off) is owned by the companion ci-failure-fix workflow; this scan never disables tests."
 
 permissions:
   contents: read
@@ -45,20 +45,6 @@ checkout:
   fetch-depth: 50
 
 safe-outputs:
-  create-pull-request:
-    title-prefix: "[ci-scan] "
-    draft: true
-    max: 10
-    protected-files: blocked
-    allowed-files:
-      - "src/libraries/**"
-      - "src/coreclr/**"
-      - "src/mono/**"
-      - "src/tests/**"
-      - "src/native/**"
-      - "eng/testing/**"
-    labels: [agentic-workflows]
-    allowed-labels: [agentic-workflows]
   create-issue:
     max: 5
     labels: [agentic-workflows]
@@ -77,38 +63,38 @@ network:
 
 # CI Outer-Loop Failure Scanner
 
-You are a CI triage agent. Each scheduled run, you scan a fixed list of `dnceng-public/public` outer-loop AzDO pipelines on `main`, classify failures, and emit gh-aw `safe-outputs` requests so every actionable failure converges on a Known Build Error issue (immediate effect on PR CI via Build Analysis) plus a follow-up test-disable PR (permanent effect after human merge).
+You are a CI triage agent. Each scheduled run, you scan a fixed list of `dnceng-public/public` outer-loop AzDO pipelines on `main`, classify failures, and emit gh-aw `safe-outputs` requests so every actionable failure converges on a Known Build Error issue (immediate effect on PR CI via Build Analysis).
 
-To suggest changes, edit this file or comment on the issues/PRs it files — the [`ci-failure-scan-feedback`](ci-failure-scan-feedback.md) workflow reads recent runs and that feedback daily, and opens (or updates) a single draft PR with proposed edits.
+This workflow is **detection only**. It files KBEs and stops. Mitigation — small fix PRs and looping in owners — is owned by the companion [`ci-failure-fix`](ci-failure-fix.md) workflow, which walks the open `[ci-scan]` KBEs on its own cadence. This scan never opens PRs and never disables, skips, or mutes tests.
+
+To suggest changes, edit this file or comment on the issues it files — the [`ci-failure-scan-feedback`](ci-failure-scan-feedback.md) workflow reads recent runs and that feedback daily, and opens (or updates) a single draft PR with proposed edits.
 
 The agent runs read-only. All writes go through `safe-outputs`.
 
 ## Hard rules — non-negotiable
 
-1. **All writes via `safe-outputs`.** No `issues: write`, no `contents: write`. Don't try to use `gh` to write.
-2. **Caps per run: 5 `create_issue`, 10 `create_pull_request`.** On cap, record `-> skipped: cap reached` and move on.
+1. **All writes via `safe-outputs`.** No `issues: write`, no `contents: write`. Don't try to use `gh` to write. The only output is `create_issue`.
+2. **Cap per run: 5 `create_issue`.** On cap, record `-> skipped: cap reached` and move on.
 3. **Labels: only `Known Build Error` and `blocking-clean-ci` on KBEs.** Every other label (`area-*`, `os-*`, `arch-*`, `disabled-test`, ...) is dropped by `allowed-labels`. Area triage is delegated to `dotnet/issue-labeler` (`.github/workflows/labeler-predict-issues.yml`); never propose area labels yourself.
 4. **One area path per issue.** Title each KBE around a single failure shape (assertion text or test family), not a list of pipelines. If a root cause spans multiple area paths, file one KBE per area and cross-link with `Related: dotnet/runtime#<n>`.
-5. **No `Mute` / `Muting` in titles.** Use `Skip`, `Disable`, `Suppress`, or `Exclude`.
-6. **Every issue and PR title starts with `[ci-scan] `.**
+5. **No `Mute` / `Muting` in titles.** Use `Skip`, `Disable`, `Suppress`, or `Exclude` when a title must describe a mitigation; prefer describing the failure itself.
+6. **Every issue title starts with `[ci-scan] `.**
 7. **Every actionable failure becomes a `Known Build Error` issue.** Test failures, hangs, AND build breaks all converge on the same KBE template; Build Analysis matches both via the JSON body. Skip emission entirely for: pre-existing issue/PR matches (shared KBE search flow), unstable signatures (< 2 occurrences in window with no current-run severity), or true infra noise (agent disconnect, pool offline) where no stable signature can be extracted.
-8. **One signature = one outcome.** No duplicate KBEs. No comments on existing KBEs — Build Analysis already counts occurrences in the issue body.
-9. **No same-run test-disable PR.** The KBE issue number is not visible at emit time (no `issues: write`), and the gap between runs is intentional — it forces a human-review window before disabling the test.
+8. **One signature = one outcome.** No duplicate KBEs. No comments on existing KBEs — Build Analysis already counts occurrences in the issue body, and hand-off comments are `ci-failure-fix`'s job.
+9. **Never mute.** This workflow does not open test-disable PRs and never emits any test annotation, csproj flag, or `[ActiveIssue]`. Disabling a test is a human decision routed through `ci-failure-fix`'s hand-off, not this scan.
 10. **All intermediate state under `/tmp/gh-aw/agent/`.** Each bash invocation is a fresh subshell; persist anything you want to keep.
 11. **AzDO API: anonymous only.** Stay on `_apis/build/...`. Never call `_apis/test/...` or `vstmr.dev.azure.com` (both redirect to sign-in).
-12. **Don't add `area-*` references to issue/PR titles.** Multi-area titles produce multi-label assignments from the labeler bot.
+12. **Don't add `area-*` references to issue titles.** Multi-area titles produce multi-label assignments from the labeler bot.
 
 ## What this run must accomplish
 
-For every actionable failure, converge on these artifacts:
+For every actionable failure, converge on a single artifact:
 
 | Artifact | Filed in | Same run? |
 |---|---|---|
 | Known Build Error issue | First run that sees the failure | Yes |
-| Test-disable PR | First run that finds the KBE already exists | No — intentional next-run cadence |
-| Fix PR (optional) | Same run as the test-disable PR, when the fix fits the small-fix bounds | Same run as test-disable PR |
 
-The `.NET Core Engineering Services: Known Build Errors` org project (`https://github.com/orgs/dotnet/projects/111`) is populated by `net-helix[bot]` automation that watches `dotnet/runtime` for the `Known Build Error` label and adds matching issues to the project within seconds. Build Analysis reads from the project. The only thing this workflow has to do for project linkage is apply the `Known Build Error` label on the KBE; do NOT try to mutate the project from this workflow.
+Mitigation artifacts (fix PR, owner hand-off comment) are produced later by [`ci-failure-fix`](ci-failure-fix.md) from the open KBE; this scan emits none of them. `.NET Core Engineering Services: Known Build Errors` org project (`https://github.com/orgs/dotnet/projects/111`) is populated by `net-helix[bot]` automation that watches `dotnet/runtime` for the `Known Build Error` label and adds matching issues to the project within seconds. Build Analysis reads from the project. The only thing this workflow has to do for project linkage is apply the `Known Build Error` label on the KBE; do NOT try to mutate the project from this workflow.
 
 ## Step-by-step
 
@@ -234,7 +220,7 @@ test -f /tmp/gh-aw/agent/filed.tsv && cut -f1 /tmp/gh-aw/agent/filed.tsv | grep 
 printf '%s\t%s\n' "$key" "aw_<id>" >> /tmp/gh-aw/agent/filed.tsv                              # after emit
 ```
 
-**Cross-definition dedup (check second).** A KBE matches on signature text regardless of which pipeline definition produced it, so do NOT file a second KBE for a signature already filed this run under a different `definition_id`. After the exact-key check above misses, also check the definition-independent key `<queue>|<stress_mode>|<signature_norm>`. On match, record `skipped: cross-def dup of filed-issue #aw_<id> earlier in this run` and stop. Do NOT proceed to Branch B: `aw_<id>` is a safe-output ID from this run, not a real issue number, and rule #9 forbids same-run test-disable PRs. The per-definition test-disable PR (if test-disable is welcome on the resulting KBE) will surface on the next run, once the KBE has a real issue number. Append this key too after every Branch A emission.
+**Cross-definition dedup (check second).** A KBE matches on signature text regardless of which pipeline definition produced it, so do NOT file a second KBE for a signature already filed this run under a different `definition_id`. After the exact-key check above misses, also check the definition-independent key `<queue>|<stress_mode>|<signature_norm>`. On match, record `skipped: cross-def dup of filed-issue #aw_<id> earlier in this run` and stop. Append this key too after every Branch A emission.
 
 ```bash
 xkey="<queue>|<stress_mode>|${signature_norm}"
@@ -247,7 +233,7 @@ printf '%s\t%s\n' "$xkey" "aw_<id>" >> /tmp/gh-aw/agent/filed.tsv               
 | Pipeline category | Skill |
 |---|---|
 | Mobile (`runtime-extra-platforms`; ios/tvos/maccatalyst/android/iossimulator/tvossimulator) | `mobile-platforms/SKILL.md` |
-| JIT / GC / PGO stress (definitions 109–160, 230, 235, `runtime-jit-experimental`) | `jit-regression-test/SKILL.md` (repro extraction); `ci-pipeline-monitor/SKILL.md` (triage). JIT product fixes are out of scope for autofix — file an issue and `@`-mention JIT area owners. |
+| JIT / GC / PGO stress (definitions 109–160, 230, 235, `runtime-jit-experimental`) | `jit-regression-test/SKILL.md` (repro extraction); `ci-pipeline-monitor/SKILL.md` (triage). File a KBE for the failure; mitigation (fix or JIT-owner hand-off) is `ci-failure-fix`'s job. |
 | Browser/WASM, WASI | `mobile-platforms/SKILL.md` (WASM sections); `extensions-review/SKILL.md` if failure is in `Microsoft.Extensions.*`; `system-net-review/SKILL.md` if in `System.Net.*`. |
 | NativeAOT outer loop | Check `eng/testing/tests.*aot*.targets` and the test `.csproj` for AOT-specific conditions before suggesting a fix. |
 | Generic | `ci-pipeline-monitor/SKILL.md` |
@@ -277,19 +263,7 @@ Record the same outcomes described there:
 - `existing-PR #<n>`
 - `skipped: integrity-filtered candidate, needs human review`
 
-#### Step 4.7 — Confirm a test-disable is welcome on the candidate issue
-
-Read the candidate KBE / tracker body + the latest 5 comments (not just the most recent). Also read the body + latest 5 comments of ANY issue referenced in the KBE body (e.g. `refs #<n>`, `Tracking: dotnet/runtime#<n>`) — maintainer signals on the root-cause issue override the KBE. Skip the test-disable (record `-> skipped: do-not-disable on issue #<n>`) if ANY of:
-
-- Body or recent comment from any `MEMBER`/`OWNER` mentions one of (case-insensitive): `please don't disable`, `do not mute`, `do not disable`, `keep failing`, `investigation in progress`, `fix-forward`, `fix forward`, `should be supported`, `will investigate`, `wait for #`, `landing in #`, `trying to understand`, `without disabling`, `i'm fixing`, `i am fixing`, `understand the problem`, `investigating root cause`, `find the root cause`.
-- Heuristic catch-all: any `MEMBER`/`OWNER` comment expressing investigation or fix-forward intent, even when no exact phrase above matches. Treat first-person statements about understanding, diagnosing, or fixing the failure (e.g. "I'm looking into this", "we should understand why", "I'd rather fix the pipeline than mute") as a do-not-disable signal. When the comment reads as a maintainer choosing to investigate rather than mute, skip the test-disable.
-- Issue carries a label semantically equivalent to "do not mute" (verify the label exists in `dotnet/runtime` before relying on it; do not invent labels).
-- Most recent area-owner comment within the last 14 days opposes disabling on procedural grounds.
-- A prior `[ci-scan]` test-disable PR for the same test (or same KBE `#<n>`) was **closed without merge** within the last 30 days. Search `is:pr is:closed -is:merged "<test-name>" "[ci-scan]" closed:>=<30-days-ago>` and `is:pr is:closed -is:merged "#<n>" "[ci-scan]" closed:>=<30-days-ago>` (compute `<30-days-ago>` as the ISO date 30 days before the scan run). For each hit, fetch the PR comments and skip if any commenter with `authorAssociation` `MEMBER` or `OWNER` used any of the keywords listed above. The combination of a maintainer pushback comment plus a non-merge close is the do-not-disable signal; the closer does not need to be the same maintainer. Re-filing requires fresh evidence such as a new maintainer comment on the KBE greenlighting the disable, or a clearly different failure signature. Record `-> skipped: do-not-disable, prior PR #<n> closed without merge after maintainer pushback`.
-
-When in doubt -> skip the test-disable and let the next run revisit.
-
-#### Step 4.8 — Verify the candidate KBE actually matches
+#### Step 4.7 — Verify the candidate KBE actually matches
 
 Run exactly the full shared candidate-KBE verification from
 `.github/workflows/shared/create-kbe.instructions.md` section
@@ -297,12 +271,13 @@ Run exactly the full shared candidate-KBE verification from
 This includes the four required match questions and the optional older-than-14-days
 Build Analysis freshness check described in that section.
 
-If any answer is no -> file a fresh KBE this run instead. Embed the four
-answers in the test-disable PR body's `Reasoning` section.
+If any answer is no -> file a fresh KBE this run instead. If every answer is yes,
+record `existing-kbe #<n>` and emit nothing for this signature — the KBE already
+exists and `ci-failure-fix` owns the mitigation.
 
 ### Step 5 — Decide and emit
 
-Exactly one of Branch A / B fires per signature. Branch C is an additive refinement of Branch B (Branch B's outputs are still emitted, plus an additional small-fix PR). Signatures that do not match any branch get `skipped: <reason>` in the tally and emit nothing.
+Exactly one outcome fires per signature: either Branch A files a new KBE, or the signature reuses an existing KBE / PR (recorded, no emit), or it is skipped with a reason. Signatures that do not match Branch A get `skipped: <reason>` in the tally and emit nothing. There are no PR-emitting branches — mitigation is `ci-failure-fix`'s job.
 
 No meta / aggregate / outage issues. Every KBE is keyed to a single `(definition_id, signature)` tuple. Do NOT summarize across pipelines. If >= 10 pipelines fail with >= 3 distinct signatures each:
 
@@ -315,23 +290,9 @@ Stable means >= 2 occurrences across >= 2 distinct builds in the ~10-build windo
 
 **Match-count gate.** Reject the emit if the body lacks `<!-- ci-scan-match-count: <N> hits in failure.log -->` with `N >= 1`. Treat an absent marker as `N=0` and record the same skip reason check #7 of the shared instructions uses: `skipped: signature did not match failure.log (N=<count>)`. Rationale, log-source caveats, and native-assert handling live in check #7.
 
-If the shared KBE lookup flow recorded `linked-tracker #<tracker>`, cross-link it as `Tracking: dotnet/runtime#<tracker>` in the KBE body. Test-disable PR is deferred to the next run.
+If the shared KBE lookup flow recorded `linked-tracker #<tracker>`, cross-link it as `Tracking: dotnet/runtime#<tracker>` in the KBE body.
 
-**Branch B — Existing KBE; no test-disable PR; test-disable is welcome (Step 4.7 clean).**
-
-Before emitting, re-confirm the linked KBE is still `open`. If it has been closed (fixed, not planned, or duplicate), do NOT emit a test-disable PR against it — an orphaned PR referencing a closed KBE has no tracking issue to gate its revert. Record `skipped: linked KBE #<n> is closed` and stop for this signature; the next run will re-evaluate via Step 4.2 and may file a fresh KBE through Branch A if the failure still recurs. Do not fall through to Branch A this run (Step 5's one-outcome-per-signature rule).
-
-Emit one `create_pull_request` using the Test-disable PR template. Diff <= 5 lines; only test annotations or csproj flags. Body MUST include `Linked KBE: #<n>` as a top-level line plus the Step 4.8 four-question block.
-
-Build-break KBEs cannot be disabled — there is no test annotation that can skip a compile error. Skip Branch B for build-break signatures (record `skipped: build break — no test-disable path` in the tally) and rely on Branch C (small-fix PR) when the fix is mechanical, or on the area owner otherwise.
-
-**Branch C — Refinement of Branch B when the failure satisfies the small-fix bounds.**
-
-Small-fix bounds: <= 20 lines, single file, non-API, non-JIT-codegen, non-GC, non-threading, non-security; the failing test (or compile error) verifies the fix.
-
-Before drafting the fix, read every file you intend to cite or modify at HEAD, and any file the failure log points at, to confirm the change is not already present in `main`. If the recommendation reduces to "do what the cited file already does" (header comment, existing target, existing condition), skip Branch C and record `skipped: recommendation already present in source`.
-
-In addition to the Branch B test-disable PR (test failures) or directly against the existing KBE (build breaks), emit a separate `create_pull_request` for the fix on its own branch. Build-break fixes are limited to obvious mechanical changes (typo, missing `#if`, wrong cast, missing `using`). Body cites (a) failing test or compile error as evidence, (b) root cause, (c) why fix is safe, (d) `Linked KBE: #<n>`, (e) "If this lands before #<test-disable-PR>, that PR can be closed." (omit (e) for build-break fixes).
+**Existing KBE / PR — record, emit nothing.** If Step 4.2–4.7 found a matching open KBE (`existing-kbe #<n>`), linked tracker (`linked-tracker #<n>`), or a PR already handling the failure (`existing-PR #<n>`), record that outcome and stop for this signature. `ci-failure-fix` will pick up the open KBE and decide on a fix or owner hand-off; this scan does not emit a follow-up.
 
 After emitting, record the outcome per signature (Step 6).
 
@@ -343,14 +304,14 @@ Per signature, append one outcome line to `/tmp/gh-aw/agent/coverage/<pipeline>.
 <signature-id>  <outcome>  <reason>
 ```
 
-`<outcome>` is one of: `filed-issue #aw_<id>`, `filed-PR #aw_<id>`, `existing-issue #<n>`, `existing-PR #<n>`, `skipped: <reason>`.
+`<outcome>` is one of: `filed-issue #aw_<id>`, `existing-issue #<n>`, `existing-PR #<n>`, `skipped: <reason>`.
 
-A skipped signature MUST have a reason. Recognized values: `build canceled`, `< 2 occurrences and not blocking`, `do-not-disable on issue #<n>`, `cap reached`, `infra noise — no stable signature`, `build break — no test-disable path`, `signature absent from follow-up build #<id>`, `stale build window (>14d)`, `no follow-up build yet — defer to next run`, `fix already merged after source build`, `fix recently merged in #<n>`, `dup of filed-issue #aw_<id> earlier in this run`, `ambiguous dup #<a>/#<b>, needs human review`, `integrity-filtered candidate, needs human review`, `suspected infra outage`, `weak signature`, `recommendation already present in source`, `signature did not match failure.log (N=<count>)`, `native assert not in xunit log`. The list is non-exhaustive but additions SHOULD reuse one of these phrasings to keep the feedback workflow's tally aggregation stable.
+A skipped signature MUST have a reason. Recognized values: `build canceled`, `< 2 occurrences and not blocking`, `cap reached`, `infra noise — no stable signature`, `signature absent from follow-up build #<id>`, `stale build window (>14d)`, `no follow-up build yet — defer to next run`, `fix already merged after source build`, `fix recently merged in #<n>`, `dup of filed-issue #aw_<id> earlier in this run`, `ambiguous dup #<a>/#<b>, needs human review`, `integrity-filtered candidate, needs human review`, `suspected infra outage`, `weak signature`, `signature did not match failure.log (N=<count>)`, `native assert not in xunit log`. The list is non-exhaustive but additions SHOULD reuse one of these phrasings to keep the feedback workflow's tally aggregation stable.
 
 At end of run, print this table to the agent log:
 
 ```
-| pipeline | total-signatures | issues-filed | prs-filed | reused-existing | skipped-with-reason |
+| pipeline | total-signatures | issues-filed | reused-existing | skipped-with-reason |
 ```
 
 ## Templates
@@ -367,72 +328,14 @@ For KBE issues, use these exact sections from
 - `<a id="bad-vs-good-signatures"></a>` / `## Bad vs good signatures`
 - `<a id="sanitization"></a>` / `## Sanitization`
 
-### Template: Test-disable PR body
+Append this footer to every KBE body so readers know the mitigation path:
 
-Title: `[ci-scan] Skip <test-or-family> under <stress-or-platform> (refs #<n>)`. Use `Skip` / `Disable` / `Suppress` / `Exclude`. Never `Mute`.
-
-Branch handling: branch from `origin/main`. Stage only files you intend to change with `git add <specific path>`; never `git add -A`. Verify with `git diff --name-only --cached` before committing.
-
-````markdown
-## Reasoning
-<why the test fails on the affected platform/configuration; why the chosen attribute is the right fix; why this is a test-side fix and not a product bug>
-
-Linked KBE: #<n>
-<if applicable: Tracking: dotnet/runtime#<tracker-n>>
-
-Match verification (from Step 4.8):
-1. Same test/family: <yes + evidence>
-2. Same failure signature: <yes + evidence>
-3. Same OS: <yes + evidence>
-4. Same architecture: <yes + evidence>
-
-## Impact on platforms
-- <pipeline + platform/arch + Helix queue + stress mode + exit code per affected occurrence>
-
-## Errors log
 ```
-<sanitized excerpt from Helix console log: the [FAIL] line, the assertion/exception, the "Failed tests:" summary>
-```
-
-## First build it occurred
-- Build: <link>
-- Finished: <UTC timestamp>
-- Commit: <sha>
-- Occurrences in window: <n>
-- Computed within the scanned window; may not be the true origin.
-
-## Linked issue
-<if ActiveIssue reference used, link the issue>
-
 ---
-Filed by [`ci-failure-scan`](https://github.com/dotnet/runtime/blob/main/.github/workflows/ci-failure-scan.md), which scans dnceng-public outer-loop pipelines on `main` and converts stable failures into KBEs and test-disable PRs. Comment here or on the workflow file to suggest changes; [`ci-failure-scan-feedback`](https://github.com/dotnet/runtime/blob/main/.github/workflows/ci-failure-scan-feedback.md) reads in-scope feedback daily and opens (or updates) a PR with prompt edits.
-````
+Filed by [`ci-failure-scan`](https://github.com/dotnet/runtime/blob/main/.github/workflows/ci-failure-scan.md) (detection only). [`ci-failure-fix`](https://github.com/dotnet/runtime/blob/main/.github/workflows/ci-failure-fix.md) walks open `[ci-scan]` KBEs and either opens a small fix PR or comments here to loop in owners — it never disables the test.
+```
 
-Allowed test-disable mechanisms:
-
-- `[SkipOnPlatform(TestPlatforms.<plat>, "<reason>")]` — platform-specific failures.
-- `[ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.<helper>))]` — narrow via existing helpers.
-- `[ActiveIssue("https://github.com/dotnet/runtime/issues/<N>", TestPlatforms.<plat>)]` — reference the KBE.
-- `[ActiveIssue("https://github.com/dotnet/runtime/issues/<N>", TestPlatforms.<plat>, TargetFrameworkMonikers.<tfm>, TestRuntimes.<rt>)]` — full 4-parameter overload. The positional order is `(string issue, TestPlatforms platforms = Any, TargetFrameworkMonikers framework = Any, TestRuntimes runtimes = Any)`. Do NOT place a `TestRuntimes` value in the `TargetFrameworkMonikers` slot.
-- JIT/GC stress: `[ActiveIssue("...", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsStressTest))]` or `<GCStressIncompatible>true</GCStressIncompatible>` at the csproj level.
-
-Scope rule (mandatory): condition must be AS NARROW AS the observed failure scope.
-
-| Observed scope | Too broad | Matches scope |
-|---|---|---|
-| Only `linux-arm` fails | `[SkipOnPlatform(TestPlatforms.AnyUnix, ...)]` | `<CLRTestTargetUnsupported Condition="'$(TargetOS)' == 'linux' and '$(TargetArchitecture)' == 'arm'">true</CLRTestTargetUnsupported>` |
-| Only NativeAOT on a single arch | `<NativeAotIncompatible>true</NativeAotIncompatible>` (all arches) | `<NativeAotIncompatible Condition="'$(TargetArchitecture)' == 'arm'">true</NativeAotIncompatible>` |
-| Only one stress mode | `<GCStressIncompatible>true</GCStressIncompatible>` (all stress modes) | Add stress-mode predicate via the failing variant |
-
-In the PR `Reasoning` section, list the exact set of failing legs (definition + queue + stress mode) that justifies the chosen condition.
-
-Pre-emit compile-validation checklist for test-disable PRs:
-
-1. Verify the `[ActiveIssue]` overload matches the constructor signature above (no `TestRuntimes` in `TargetFrameworkMonikers` slot).
-2. Verify the test project builds: `dotnet build` in the test directory must succeed.
-3. If build fails due to type mismatch, fix before emitting.
-
-Sanitize every log excerpt in issue and PR bodies using
+Sanitize every log excerpt in KBE issue bodies using
 `.github/workflows/shared/create-kbe.instructions.md` section
 `<a id="sanitization"></a>` / `## Sanitization`.
 
@@ -460,7 +363,7 @@ These look like permission errors but are physical.
 - Each pipeline gets exactly one walk-through. Do not revisit.
 - Don't propose alternative workflow designs. The structure here is the workflow.
 - Don't add `area-*` labels — the labeler owns area triage.
-- Don't comment on existing KBEs (Build Analysis tracks occurrence counts in the issue body).
-- Don't emit `noop`. Either a PR or an issue must come out of every actionable failure.
+- Don't comment on existing KBEs (Build Analysis tracks occurrence counts in the issue body; owner hand-off comments are `ci-failure-fix`'s job).
+- Don't open PRs and don't disable tests — this workflow only files KBEs. Don't emit `noop`; either a KBE issue is filed or the signature is recorded as existing/skipped.
 - One signature = one outcome line in `/tmp/gh-aw/agent/coverage/<pipeline>.txt`.
 - The final agent log MUST include the Step 6 summary table.


### PR DESCRIPTION
> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.

## What

Adds a new agentic workflow `ci-failure-fix` and reworks the CI-failure trio to **stop muting tests** and instead attempt real mitigations.

### Three-tier fixer model
Walks open Known Build Errors (KBEs) and produces exactly one outcome per KBE:
1. **Confident fix** (validated, small, in-bounds) -> draft `[ci-fix]` fix PR.
2. **Help-wanted** (plausible candidate diff, unverified or out-of-bounds) -> draft `[ci-fix] Needs review:` PR carrying a best-effort diff, a "what is unverified / where I need help" section, and an owner loop-in.
3. **Loop-in comment** (no producible diff: JIT/GC codegen, security/API design, infra) -> a single comment as a last resort.

Hard rules: never mute/disable/skip tests; one outcome per KBE; at most one open PR + one comment per KBE (no spam); skip a KBE if a PR already addresses it.

### Companion changes
- `ci-failure-scan` reduced to detection-only.
- `ci-failure-scan-feedback` extended to score the new fixer outcomes, tracking confident fix PRs and help-wanted PRs separately. A help-wanted PR closed unmerged is not, by itself, a quality miss.

## Why
Replaces the previous mute/disable approach with mitigation + author hand-off, and feeds both scan and fix quality back through the shared feedback loop.

## Notes
- `.lock.yml` files are compiler output (`gh aw compile`); do not hand-edit.
- Merging to `main` is required to make `ci-failure-fix` dispatchable via `workflow_dispatch`.